### PR TITLE
Add feature of importing labels from json file

### DIFF
--- a/automan/api/projects/annotations/urls.py
+++ b/automan/api/projects/annotations/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^(?P<annotation_id>\d+)/$', views.annotation, name='annotation'),
     url(r'^(?P<annotation_id>\d+)/archive/$', views.download_archived_annotation, name='download_archived_annotation'),
     url(r'^(?P<annotation_id>\d+)/frames/(?P<frame>\d+)/objects/$', views.frame, name='frame'),
+    url(r'^(?P<annotation_id>\d+)/import_labels_from_json/$', views.import_labels_from_json, name='import_labels_from_json'),
 ]

--- a/automan/api/projects/annotations/views.py
+++ b/automan/api/projects/annotations/views.py
@@ -134,4 +134,4 @@ def import_labels_from_json(request, project_id, annotation_id):
             deleted = []
 
             annotation_manager.set_frame_label(user_id, project_id, annotation_id, frame_id, created, edited, deleted)
-        return HttpResponse(content=json.dumps(request.data), status=200, content_type='application/json')
+        return HttpResponse(status=201)

--- a/automan/api/projects/annotations/views.py
+++ b/automan/api/projects/annotations/views.py
@@ -96,3 +96,10 @@ def download_archived_annotation(request, project_id, annotation_id):
     archive_path = annotation_manager.get_archive_path(annotation_id)
     archive = open(archive_path, "rb").read()
     return HttpResponse(archive, content_type="application/octet-stream")
+
+
+@api_view(['POST'])
+def import_labels_from_json(request, project_id, annotation_id):
+    if request.method == 'POST':
+        print(request.data.keys())
+        return HttpResponse(content=json.dumps(request.data), status=200, content_type='application/json')

--- a/automan/api/projects/annotations/views.py
+++ b/automan/api/projects/annotations/views.py
@@ -100,11 +100,11 @@ def download_archived_annotation(request, project_id, annotation_id):
 
 @api_view(['POST'])
 def import_labels_from_json(request, project_id, annotation_id):
-    def convert_bbox(bbox):
+    def convert_bbox(bbox, candidate_id):
         return {
                     'name': bbox['class'].lower(),
                     'content': {
-                        '2': {
+                        '{}'.format(candidate_id): {
                             'x_3d': bbox['x'],
                             'y_3d': bbox['y'],
                             'z_3d': bbox['z'],
@@ -118,18 +118,18 @@ def import_labels_from_json(request, project_id, annotation_id):
 
     username = request.user
     user_id = AccountManager.get_id_by_username(username)
+    candidate_id = request.data.get('candidateId')
+    data = request.data.get('labelJson')
     annotation_manager = AnnotationManager()
 
     if request.method == 'POST':
-        # Get data
-        data = request.data
         # Get all frame ids
         frame_ids = data.keys()
         for frame_id in frame_ids:
             bboxes = data[frame_id]
             frame_id = '{}'.format(int(frame_id)) # Temporarily: avoiding error because of zero-padded frame ID
 
-            created = [convert_bbox(bbox) for bbox in bboxes]
+            created = [convert_bbox(bbox, candidate_id) for bbox in bboxes]
             edited = []
             deleted = []
 

--- a/front/app/dashboard/components/annotation/label_import_dialog.jsx
+++ b/front/app/dashboard/components/annotation/label_import_dialog.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import CardHeader from '@material-ui/core/CardHeader';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import FormControl from '@material-ui/core/FormControl'
+import Close from '@material-ui/icons/Close';
+import Send from '@material-ui/icons/Send';
+
+
+export default class LabelImportDialog extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      formOpen: false,
+      file: null,
+    };
+  }
+
+  show = () => {
+    this.setState({ formOpen: true });
+  }
+
+  hide = () => {
+    this.setState({ formOpen: false });
+  }
+
+  handleChangeFile = (e) => {
+    const file = e.target.files.item(0);
+    this.setState({ file: file });
+  }
+
+  handleSubmit = () => {
+    // Define data reader
+    var reader = new FileReader();
+    // Get text
+    reader.readAsText(this.state.file);
+    // After loading
+    reader.addEventListener( 'load', function() {
+      // Parse JSON
+      const data = JSON.parse(reader.result);
+      // Set url for API
+      let url = `/projects/${this.props.project_id}/annotations/${this.props.annotation_id}/import_labels_from_json/`;
+      // Post request
+      RequestClient.post(
+        url,
+        data,
+        function(res) {
+          console.log(res);
+        },
+        function(mes) {
+          console.log(mes);
+        }
+      );
+    }.bind(this));
+  }
+
+  render() {
+    const closeButton = (
+      <Button
+        onClick={this.hide}
+      >
+        <Close />
+      </Button>
+    );
+
+    return (
+      <span>
+        <a
+          className="button glyphicon glyphicon-import"
+          onClick={this.show}
+          title="Import"
+        />
+
+        <div>
+          <Dialog
+            open={this.state.formOpen}
+            aria-labelledby="form-dialog-title"
+          >
+            <CardHeader action={closeButton} title="Import Labels from JSON" />
+            <DialogContent>
+              <FormControl>
+                <input
+                  type="file"
+                  onChange={(e) => this.handleChangeFile(e)}
+                />
+              </FormControl>
+
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={this.handleSubmit}
+              >
+                <Send />&nbsp;Submit
+              </Button>
+            </DialogContent>
+          </Dialog>
+        </div>
+
+      </span>
+    );
+  }
+}

--- a/front/app/dashboard/components/annotation/label_import_dialog.jsx
+++ b/front/app/dashboard/components/annotation/label_import_dialog.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
 import CardHeader from '@material-ui/core/CardHeader';
+import { amber, green } from '@material-ui/core/colors';
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import FormControl from '@material-ui/core/FormControl'
+import SnackbarContent from '@material-ui/core/SnackbarContent';
 import Close from '@material-ui/icons/Close';
 import Send from '@material-ui/icons/Send';
 
@@ -14,6 +16,8 @@ export default class LabelImportDialog extends React.Component {
     this.state = {
       formOpen: false,
       file: null,
+      isImportSuccess: null,
+      message: '',
     };
   }
 
@@ -45,12 +49,14 @@ export default class LabelImportDialog extends React.Component {
       RequestClient.post(
         url,
         data,
-        function(res) {
-          console.log(res);
-        },
-        function(mes) {
-          console.log(mes);
-        }
+        function() {
+          this.setState({ isImportSuccess: true });
+          this.setState({ message: '成功しました' });
+        }.bind(this),
+        function() {
+          this.setState({ isImportSuccess: false });
+          this.setState({ message: '失敗しました' });
+        }.bind(this)
       );
     }.bind(this));
   }
@@ -62,6 +68,26 @@ export default class LabelImportDialog extends React.Component {
       >
         <Close />
       </Button>
+    );
+
+    const successMessage = (
+      <SnackbarContent 
+        message={this.state.message}
+        style={{
+          backgroundColor: green[600],
+          marginTop: '15px',
+        }}
+      />
+    );
+
+    const errorMessage = (
+      <SnackbarContent 
+        message={this.state.message}
+        style={{
+          backgroundColor: amber[700],
+          marginTop: '15px',
+        }}
+      />
     );
 
     return (
@@ -86,13 +112,18 @@ export default class LabelImportDialog extends React.Component {
                 />
               </FormControl>
 
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={this.handleSubmit}
-              >
-                <Send />&nbsp;Submit
-              </Button>
+              <div style={{ marginTop: '15px' }}>
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={this.handleSubmit}
+                >
+                  <Send />&nbsp;Submit
+                </Button>
+              </div>
+
+              {this.state.isImportSuccess === true ? successMessage : null}
+              {this.state.isImportSuccess === false ? errorMessage : null}
             </DialogContent>
           </Dialog>
         </div>

--- a/front/app/dashboard/components/annotation/table.jsx
+++ b/front/app/dashboard/components/annotation/table.jsx
@@ -182,6 +182,10 @@ class AnnotationTable extends React.Component {
                     onClick={e => this.handleArchive(row)}
                     title="Archive"
                   />
+                  <LabelImportDialog
+                    project_id={this.props.currentProject.id}
+                    annotation_id={row.id}
+                  />
                 </span>
               </div>
             );

--- a/front/app/dashboard/components/annotation/table.jsx
+++ b/front/app/dashboard/components/annotation/table.jsx
@@ -170,6 +170,7 @@ class AnnotationTable extends React.Component {
                   <LabelImportDialog
                     project_id={this.props.currentProject.id}
                     annotation_id={row.id}
+                    dataset_id={row.dataset_id}
                   />
                 </span>
               </div>
@@ -186,6 +187,7 @@ class AnnotationTable extends React.Component {
                   <LabelImportDialog
                     project_id={this.props.currentProject.id}
                     annotation_id={row.id}
+                    dataset_id={row.dataset_id}
                   />
                 </span>
               </div>

--- a/front/app/dashboard/components/annotation/table.jsx
+++ b/front/app/dashboard/components/annotation/table.jsx
@@ -6,6 +6,7 @@ import { TableHeaderColumn } from 'react-bootstrap-table';
 import Typography from '@material-ui/core/Typography';
 
 import ResizableTable from 'automan/dashboard/components/parts/resizable_table';
+import LabelImportDialog from 'automan/dashboard/components/annotation/label_import_dialog';
 import { mainStyle } from 'automan/assets/main-style';
 
 function actionFormatter(cell, row) {

--- a/front/app/dashboard/components/annotation/table.jsx
+++ b/front/app/dashboard/components/annotation/table.jsx
@@ -166,6 +166,10 @@ class AnnotationTable extends React.Component {
                     }}
                     title="Download"
                   />
+                  <LabelImportDialog
+                    project_id={this.props.currentProject.id}
+                    annotation_id={row.id}
+                  />
                 </span>
               </div>
             );


### PR DESCRIPTION
## Description

- Added feature of importing labels because we wanted to import inferred labels by machine learning model.
- Added dialog form for uploading json file (currently the structure of json file is based on the older version of Automan).
- Added API that converts requested json and added objects to the database.

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)

- Click import button in Actions column.

<img width="1231" alt="スクリーンショット 2019-09-05 11 58 41" src="https://user-images.githubusercontent.com/13210107/64308673-04fa3180-cfd5-11e9-88da-86c77b0c5acc.png">

- Select json file.

<img width="1231" alt="スクリーンショット 2019-09-05 11 58 50" src="https://user-images.githubusercontent.com/13210107/64308717-31ae4900-cfd5-11e9-853b-fa1d7298317a.png">

- Click submit button and importing succeeded.

<img width="1231" alt="スクリーンショット 2019-09-05 11 58 55" src="https://user-images.githubusercontent.com/13210107/64308734-3ecb3800-cfd5-11e9-96da-2b47bfcff498.png">

- Open annotation.

<img width="1231" alt="スクリーンショット 2019-09-05 11 59 32" src="https://user-images.githubusercontent.com/13210107/64308773-66220500-cfd5-11e9-9173-6e0ae273fe49.png">
