### PR TITLE
Exclude node_modules directory from docker-compose volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
         container_name: automan-tools
         volumes:
             - .:/opt/automan:rw
+            - /opt/automan/front/node_modules
             - /Volumes/docker/kubernetes/kube-dev/default-app-pv-claim-pvc-801c442a-91a8-4937-9bff-6a1266b89689:/share:rw
         ports:
             - 8000:8000


### PR DESCRIPTION
`node_modules` のディレクトリを別のボリュームに隔離した。

初回起動するために `docker-compose build` から `docker-compose up` したときに、ホストマシンにはnode_modulesディレクトリが無い状態でマウントして、node_modulesが参照できずエラーが発生したため。
