### PR TITLE
Disable inputting when loading

### DIFF
--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -43,7 +43,8 @@ class Controls extends React.Component {
     this.state = {
       frameNumber: 0,
       skipFrameCount: 1,
-      activeTool: 0
+      activeTool: 0,
+      isLoading: false,
     };
 
     this.frameLength = props.labelTool.frameLength;
@@ -350,6 +351,7 @@ class Controls extends React.Component {
     }
 
     this.isLoading = true;
+    this.setState({ isLoading: true });
     return this.props.labelTool.loadBlobURL(num)
       .then(() => {
         return this.props.annotation.load(num);
@@ -369,6 +371,7 @@ class Controls extends React.Component {
       })
       .then(() => {
         this.isLoading = false;
+        this.setState({ isLoading: false });
         this.setState({frameNumber: num});
       });
   }
@@ -428,6 +431,7 @@ class Controls extends React.Component {
   // events
   onClickLogout = (e) => {
     this.isLoading = true;
+    this.setState({ isLoading: true });
     RequestClient.delete(
       this.props.labelTool.getURL('unlock'),
       null,
@@ -639,10 +643,12 @@ class Controls extends React.Component {
           {this.toolComponents}
         </main>
         {this.renderRightBar(classes)}
-        {/* <LoadingProgress
-          text="Prefetching Files"
-          progress={this.props.loadingState}
-        /> */}
+        { this.state.isLoading &&
+          <LoadingProgress
+            text="Loading"
+            progress={null}
+          />
+        }
       </div>
     );
   }

--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -106,7 +106,7 @@ class Controls extends React.Component {
   initEvent() {
     $(window)
       .keydown(e => {
-        if (this.isLoading) {
+        if (this.state.isLoading) {
           return;
         }
         if (e.keyCode == 8 || e.keyCode == 46) {
@@ -143,7 +143,7 @@ class Controls extends React.Component {
         }
       })
       .keyup(e => {
-        if (this.isLoading) {
+        if (this.state.isLoading) {
           return;
         }
         this.getTool().handles.keyup(e);
@@ -341,7 +341,7 @@ class Controls extends React.Component {
       );
   }
   loadFrame(num) {
-    if (this.isLoading) {
+    if (this.state.isLoading) {
       return Promise.reject('duplicate loading');
     }
     this.selectLabel(null);
@@ -350,7 +350,6 @@ class Controls extends React.Component {
       num = this.state.frameNumber;
     }
 
-    this.isLoading = true;
     this.setState({ isLoading: true });
     return this.props.labelTool.loadBlobURL(num)
       .then(() => {
@@ -370,7 +369,6 @@ class Controls extends React.Component {
         );
       })
       .then(() => {
-        this.isLoading = false;
         this.setState({ isLoading: false });
         this.setState({frameNumber: num});
       });
@@ -430,7 +428,6 @@ class Controls extends React.Component {
 
   // events
   onClickLogout = (e) => {
-    this.isLoading = true;
     this.setState({ isLoading: true });
     RequestClient.delete(
       this.props.labelTool.getURL('unlock'),


### PR DESCRIPTION
- フレーム遷移中にもう一度遷移するとエラーになるため、遷移中はボタンを押せないようにした
- `isLoading` ステートを追加

![画面収録 2020-06-30 19 27 23](https://user-images.githubusercontent.com/13210107/86116512-85f85b80-bb08-11ea-8d35-857a6699d230.gif)
