### PR TITLE
Auto deploy to kube-dev cluster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - develop
-      - develop-hdl
 
 jobs:
   docker:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -7,34 +7,34 @@ on:
       - feature/ci-auto-deploy
 
 jobs:
-  build:
-    runs-on: ubuntu-18.04
-    timeout-minutes: 300
-
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Build image
-        env:
-          TAG: ${{ github.ref }}
-        shell: bash
-        run: |
-          docker build -t hdwlab/automan-tools:${TAG##*/} .
-
-      - name: Push to DockerHub
-        env:
-          TAG: ${{ github.ref }}
-          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-        shell: bash
-        run: |
-          docker login -u ${DOCKER_USER} -p ${DOCKER_PASS} \
-          && docker push hdwlab/automan-tools:${TAG##*/}
+#  build:
+#    runs-on: ubuntu-18.04
+#    timeout-minutes: 300
+#
+#    steps:
+#      - uses: actions/checkout@v1
+#
+#      - name: Build image
+#        env:
+#          TAG: ${{ github.ref }}
+#        shell: bash
+#        run: |
+#          docker build -t hdwlab/automan-tools:${TAG##*/} .
+#
+#      - name: Push to DockerHub
+#        env:
+#          TAG: ${{ github.ref }}
+#          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+#          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+#        shell: bash
+#        run: |
+#          docker login -u ${DOCKER_USER} -p ${DOCKER_PASS} \
+#          && docker push hdwlab/automan-tools:${TAG##*/}
 
   deploy-dev:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
-    needs: build
+#    needs: build
     steps:
       - name: Deploy to cluster
         uses: steebchen/kubectl@master

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -32,7 +32,7 @@ jobs:
           && docker push hdwlab/automan-tools:${TAG##*/}
 
   deploy-dev:
-    runs-on: takedalab-dev
+    runs-on: ubuntu-18.04
     timeout-minutes: 30
     needs: build
     steps:

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -4,37 +4,36 @@ on:
   push:
     branches:
       - develop-hdl
-      - feature/ci-auto-deploy
 
 jobs:
-#  build:
-#    runs-on: ubuntu-18.04
-#    timeout-minutes: 300
-#
-#    steps:
-#      - uses: actions/checkout@v1
-#
-#      - name: Build image
-#        env:
-#          TAG: ${{ github.ref }}
-#        shell: bash
-#        run: |
-#          docker build -t hdwlab/automan-tools:${TAG##*/} .
-#
-#      - name: Push to DockerHub
-#        env:
-#          TAG: ${{ github.ref }}
-#          DOCKER_USER: ${{ secrets.DOCKER_USER }}
-#          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
-#        shell: bash
-#        run: |
-#          docker login -u ${DOCKER_USER} -p ${DOCKER_PASS} \
-#          && docker push hdwlab/automan-tools:${TAG##*/}
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 300
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Build image
+        env:
+          TAG: ${{ github.ref }}
+        shell: bash
+        run: |
+          docker build -t hdwlab/automan-tools:${TAG##*/} .
+
+      - name: Push to DockerHub
+        env:
+          TAG: ${{ github.ref }}
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        shell: bash
+        run: |
+          docker login -u ${DOCKER_USER} -p ${DOCKER_PASS} \
+          && docker push hdwlab/automan-tools:${TAG##*/}
 
   deploy-dev:
     runs-on: ubuntu-18.04
     timeout-minutes: 30
-#    needs: build
+    needs: build
     steps:
       - name: Deploy to cluster
         uses: steebchen/kubectl@master

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -1,0 +1,51 @@
+name: Build, Push and Deploy
+
+on:
+  push:
+    branches:
+      - develop-hdl
+      - feature/ci-auto-deploy
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 300
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Build image
+        env:
+          TAG: ${{ github.ref }}
+        shell: bash
+        run: |
+          docker build -t hdwlab/automan-tools:${TAG##*/} .
+
+      - name: Push to DockerHub
+        env:
+          TAG: ${{ github.ref }}
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+        shell: bash
+        run: |
+          docker login -u ${DOCKER_USER} -p ${DOCKER_PASS} \
+          && docker push hdwlab/automan-tools:${TAG##*/}
+
+  deploy-dev:
+    runs-on: takedalab-dev
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - name: Deploy to cluster
+        uses: steebchen/kubectl@master
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_DEV_CONFIG_DATA }}
+        with:
+          args: '"rollout restart deployment/automan-labeling-app"'
+      - name: Verify deployment
+        uses: steebchen/kubectl@master
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_DEV_CONFIG_DATA }}
+          KUBECTL_VERSION: "1.17"
+        with:
+          args: '"rollout status deployment/automan-labeling-app"'


### PR DESCRIPTION
# What
- `develop-hdl` へのマージ時に開発用k8sクラスタに自動デプロイするCIを追加

# Why
- 開発最新版を簡単に確認できるようにするため