### PR TITLE
Add prefetch next frame

### DIFF
--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -374,6 +374,12 @@ class Controls extends React.Component {
         }
       );
   }
+
+  // Validate number of frame
+  validateFrameNumber(frameNumber) {
+    return !isNaN(frameNumber) && 0 < frameNumber && frameNumber < this.frameLength;
+  }
+
   loadFrame(num) {
     if (this.state.isLoading) {
       return Promise.reject('duplicate loading');
@@ -384,6 +390,12 @@ class Controls extends React.Component {
       num = this.state.frameNumber;
     }
 
+    // Prefetch next frame if exists
+    const nextFrameNumber = num + Math.max(1, this.state.skipFrameCount);
+    if (this.validateFrameNumber(nextFrameNumber)) {
+      this.props.labelTool.loadBlobURL(nextFrameNumber);
+    }
+
     this.setState({ isLoading: true });
     return this.props.labelTool.loadBlobURL(num)
       .then(() => {
@@ -391,6 +403,11 @@ class Controls extends React.Component {
       })
       // Load previous frame data for wipe
       .then(() => {
+        // FIXME: Load previous frame with skip step like below, but need to fix the previous frame wipe bug first
+        // const previousFrameNumber = num - Math.max(1, this.state.skipFrameCount);
+        // if (this.validateFrameNumber(previousFrameNumber)) {
+        //   return this.props.labelTool.loadBlobURL(previousFrameNumber);
+        // }
         if (num > 1) {
           return this.props.labelTool.loadBlobURL(num - 1);
         }


### PR DESCRIPTION
## What?

- フレーム読み込み時に、次フレームもプリフェッチする機能を追加
- 次フレームはskip stepを考慮して設定
- ついでにフレーム番号をバリデーションする部分を関数化

## Why?

動作を高速化したい

## 積み残し

ワイプで読み込むフレームのバグ（仕様？）を修正したあとに、ワイプ用プリフェッチでskip stepを考慮するように変更
-> https://github.com/TakedaLab/AutomanTools/pull/23/files#diff-65c0bfc8816f4fdf0f170271b2c793a5R406-R410

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]
