### PR TITLE
Change keymap for change_edit_mode, fix shift+size_change behavior

### DIFF
--- a/front/app/labeling_tool/key_control/README.md
+++ b/front/app/labeling_tool/key_control/README.md
@@ -1,0 +1,23 @@
+Keymap Definition
+===
+
+Keymap definition was designed based on [Sublime Text Key Bindings](https://www.sublimetext.com/docs/3/key_bindings.html).
+
+## Modifiers
+
+- alt
+- ctrl
+- meta
+- shift
+
+## Key Names
+
+Refer keyCode definition: [KeyboardEvent.keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode)
+
+## Key Mapping
+
+`keys` accepts following expression:
+
+```
+((alt|ctrl|meta|shift)\+)*(<keyCode>)
+```

--- a/front/app/labeling_tool/key_control/index.stories.jsx
+++ b/front/app/labeling_tool/key_control/index.stories.jsx
@@ -29,10 +29,10 @@ class Example extends React.Component{
     addKeyCommand("history_undo", () => this.setState({undo: this.state.undo + 1}))
     document.addEventListener("keydown", (e) => {
       execKeyCommand("history_redo", e, () => this.setState({redo: this.state.redo + 1}))
-      execKeyCommand("change_editMode", e, () => this.setState({editMode: "view"}))
+      execKeyCommand("change_edit_mode", e, () => this.setState({editMode: "view"}))
     })
     document.addEventListener("keyup", (e) => {
-      execKeyCommand("change_editMode", e, () => {
+      execKeyCommand("change_edit_mode", e, () => {
         this.setState({editMode: "edit"})
         })
     })
@@ -56,7 +56,7 @@ class Example extends React.Component{
           </tr>
           <tr>
             <th>editMode</th>
-            <td>shift</td>
+            <td>space</td>
             <td>{editMode}</td>
           </tr>
         </table>

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -1,30 +1,7 @@
-// MODIFIERS
-// ---------
-// - alt
-// - ctrl
-// - meta
-// - shift
-//
-// KEY NAMES
-// ---------
-// Refer keyCode definition
-// https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
-//
-// KEY MAPPING
-// -----------
-// `keys` accepts:
-// ((alt|ctrl|meta|shift)\+)*(<keyCode>)
-//
-// MISC
-// ----
-// This key map definition was designed based on Sublime Text Key Bindings:
-// https://www.sublimetext.com/docs/3/key_bindings.html
-//
-
 export const keymapDefault = [
   //view
   {
-    "keys": ["shift+ShiftLeft", "shift+ShiftRight", "ShiftLeft", "ShiftRight"],
+    "keys": ["Space"],
     "command": "change_edit_mode"
   },
 
@@ -116,35 +93,35 @@ export const keymapDefault = [
 
     // size
   {
-    "keys": ["alt+ArrowUp"],
+    "keys": ["alt+shift+ArrowUp"],
     "command": "bbox_x_size_increment",
   },
   {
-    "keys": ["alt+shift+ArrowUp"],
+    "keys": ["alt+ArrowUp"],
     "command": "bbox_x_size_increment_big",
   },
   {
-    "keys": ["alt+ArrowDown"],
+    "keys": ["alt+shift+ArrowDown"],
     "command": "bbox_x_size_decrement",
   },
   {
-    "keys": ["alt+shift+ArrowDown"],
+    "keys": ["alt+ArrowDown"],
     "command": "bbox_x_size_decrement_big",
   },
   {
-    "keys": ["alt+ArrowLeft"],
+    "keys": ["alt+shift+ArrowLeft"],
     "command": "bbox_y_size_increment",
   },
   {
-    "keys": ["alt+shift+ArrowLeft"],
+    "keys": ["alt+ArrowLeft"],
     "command": "bbox_y_size_increment_big",
   },
   {
-    "keys": ["alt+ArrowRight"],
+    "keys": ["alt+shift+ArrowRight"],
     "command": "bbox_y_size_decrement",
   },
   {
-    "keys": ["alt+shift+ArrowRight"],
+    "keys": ["alt+ArrowRight"],
     "command": "bbox_y_size_decrement_big",
   },
   {


### PR DESCRIPTION
## What?

- キーでボックス移動・サイズ変更するときに画面も動いてしまう問題を修正
- カメラ移動コマンドを `shift+マウス操作` から `Space+マウス操作` に変更
 	- `Space+スクロール`: ズーム
	- `Space+左ドラッグ`: 視点移動
	- `Space+右ドラッグ`: 平行移動
- サイズ変更のキーマップを修正

## Why?

- バグ修正のため

## See also [Optional]
- https://www.notion.so/humandatawarelab/Automan-f27b771c414745d5a1206aa934f902f3