### PR TITLE
HDL Key-bind

### DIFF
--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -160,16 +160,16 @@ class Controls extends React.Component {
                       }
                       switch(action){
                         case "increment":
-                          box_d[param][axis] = 0.5
+                          box_d[param][axis] = 0.05
                           break
                         case "decrement":
-                          box_d[param][axis] = -0.5
+                          box_d[param][axis] = -0.05
                           break
                         case "increment_big":
-                          box_d[param][axis] = 5
+                          box_d[param][axis] = 0.5
                           break
                         case "decrement_big":
-                          box_d[param][axis] = -5
+                          box_d[param][axis] = -0.5
                           break
                       }
                       execKeyCommand(command, e.originalEvent, () => {

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -1,7 +1,7 @@
 export const keymapDefault = [
   //view
   {
-    "keys": ["shift+ShiftLeft", "shift+ShiftRight", "ShiftLeft", "ShiftRight"],
+    "keys": ["shift+ShiftLeft", "shift+ShiftRight", "ShiftLeft", "ShiftRight", "Space"],
     "command": "change_edit_mode"
   },
 

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -1,7 +1,7 @@
 export const keymapDefault = [
   //view
   {
-    "keys": ["Space"],
+    "keys": ["shift+ShiftLeft", "shift+ShiftRight", "ShiftLeft", "ShiftRight"],
     "command": "change_edit_mode"
   },
 
@@ -14,7 +14,7 @@ export const keymapDefault = [
     "keys": ["ctrl+shift+KeyZ", "meta+shift+KeyZ"],
     "command": "history_redo"
   },
-  
+
   // frame
   {
     "keys": ["KeyN"],
@@ -28,7 +28,7 @@ export const keymapDefault = [
 
   // bbox control
   {
-    "keys": ["Delete", "Backspace"],
+    "keys": ["Delete", "Backspace", "KeyD"],
     "command": "bbox_remove",
   },
   {

--- a/front/app/labeling_tool/pcd_tool/input_incremental.jsx
+++ b/front/app/labeling_tool/pcd_tool/input_incremental.jsx
@@ -33,8 +33,8 @@ const IncrementButton = props => {
 const InputIncremental = props => {
   const {
     label = "",
-    increment_small = 0.1,
-    increment_large = 1,
+    increment_small = 0.05,
+    increment_large = 0.5,
     incrementValue,
     ...otherProps
   } = props;

--- a/front/static/js/labeling_tool/OrbitControls.js
+++ b/front/static/js/labeling_tool/OrbitControls.js
@@ -70,10 +70,11 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.enableKeys = true;
 
 	// The four arrow keys
-	this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
+	// this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };
 
 	// Mouse buttons
-	this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
+	// this.mouseButtons = { ORBIT: THREE.MOUSE.LEFT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.RIGHT };
+  this.mouseButtons = { ORBIT: THREE.MOUSE.RIGHT, ZOOM: THREE.MOUSE.MIDDLE, PAN: THREE.MOUSE.LEFT };
 
 	// for reset
 	this.target0 = this.target.clone();


### PR DESCRIPTION
## What?
(概要など)
キーバインド等をHDL向けにカスタマイズ
- viewモードでのマウスボタンのマッピングを変更
  - 左ドラッグ: 回転 -> 平行移動
  - 右ドラッグ: 平行移動 -> 回転
- `Shift+矢印キー` による画面全体の平行移動を無効化
- viewモードへの切り替えキーに `Shift` を追加
  - `Space` キーだとアクティブなコンポーネントのonclickイベントが発動してしまうから
- `D` キーでbboxを削除できるように設定
- サイドバーのボタンによるbboxのパラメータ変更の間隔をより細かく設定
- 矢印キーによるbboxのパラメータの変更間隔をより細かく設定

## Why?
使いやすくするため