### PR TITLE
Reset camera with 0 key

### DIFF
--- a/front/app/labeling_tool/key_control/index.js
+++ b/front/app/labeling_tool/key_control/index.js
@@ -7,30 +7,6 @@ const modifiers = {
   metaKey: "meta"
 }
 
-export const addKeyCommand = (command, callback) => {
-  // add event listner to document
-  keymap.forEach((objBind) => {
-    if(objBind.command !== command){
-      
-    }else{
-      objBind.keys.forEach((objKey) => {
-        const lits = objKey.split("+")
-        // TODO: only shift
-        const m = {
-          altKey:   lits.includes(modifiers.altKey),
-          ctrlKey:  lits.includes(modifiers.ctrlKey),
-          shiftKey: lits.includes(modifiers.shiftKey),
-          metaKey:  lits.includes(modifiers.metaKey),
-          code:     lits[lits.length - 1]
-        }
-        document.addEventListener("keydown", (e) => {
-          execCommand(e, m, callback)
-        }, false)
-      })
-    }
-  })
-}
-
 export const execKeyCommand = (command, e, callback) => {
   // exec key command
   keymap.forEach((objBind) => {

--- a/front/app/labeling_tool/key_control/index.stories.jsx
+++ b/front/app/labeling_tool/key_control/index.stories.jsx
@@ -4,7 +4,7 @@ import { withKnobs, text, boolean, button } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions'
 
 import { keymap as keymapObject } from './key_map/index'
-import { addKeyCommand, execKeyCommand } from './index'
+import { execKeyCommand } from './index'
 
 import {
   Button,
@@ -26,8 +26,8 @@ class Example extends React.Component{
     editMode: "edit"
   }
   componentDidMount(){
-    addKeyCommand("history_undo", () => this.setState({undo: this.state.undo + 1}))
     document.addEventListener("keydown", (e) => {
+      execKeyCommand("history_undo", e, () => this.setState({undo: this.state.undo + 1}))
       execKeyCommand("history_redo", e, () => this.setState({redo: this.state.redo + 1}))
       execKeyCommand("change_edit_mode", e, () => this.setState({editMode: "view"}))
     })

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -4,6 +4,10 @@ export const keymapDefault = [
     "keys": ["shift+ShiftLeft", "shift+ShiftRight", "ShiftLeft", "ShiftRight", "Space"],
     "command": "change_edit_mode"
   },
+  {
+    "keys": ["Digit0"],
+    "command": "reset_camera",
+  },
 
   // history
   {

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -247,7 +247,8 @@ class PCDLabelTool extends React.Component {
         this.modeChangeRequest('view');
       })
       execKeyCommand("reset_camera", e.originalEvent, () => {
-        this._initCamera();
+        // Reset camera potision to when saveState called
+        this._cameraControls.reset();
         this.redrawRequest();
       });
     },
@@ -439,6 +440,8 @@ class PCDLabelTool extends React.Component {
 
     this._camera = camera;
     this._cameraControls = controls;
+    // Save camera parameters for later reset
+    this._cameraControls.saveState();
   }
   _initDom() {
     const wrapper = $(this._wrapperElement.current);

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -12,7 +12,7 @@ import BoxFrameObject from './pcd_tool/box_frame_object';
 import PCDBBox from './pcd_tool/pcd_bbox';
 import EditBar from './pcd_tool/edit_bar';
 
-import { addKeyCommand, execKeyCommand } from './key_control/index'
+import { execKeyCommand } from './key_control/index'
 
 // 3d eidt arrow
 const arrowColors = [0xff0000, 0x00ff00, 0x0000ff],
@@ -246,6 +246,10 @@ class PCDLabelTool extends React.Component {
       execKeyCommand("change_edit_mode", e.originalEvent, () => {
         this.modeChangeRequest('view');
       })
+      execKeyCommand("reset_camera", e.originalEvent, () => {
+        this._initCamera();
+        this.redrawRequest();
+      });
     },
     keyup: (e) => {
       execKeyCommand("change_edit_mode", e.originalEvent, () => {
@@ -464,12 +468,6 @@ class PCDLabelTool extends React.Component {
     zPlane.rotation.x = Math.PI / 2;
     zPlane.rotation.order = 'ZXY';
     this._zPlane = zPlane;
-
-    // Register key commands
-    addKeyCommand("reset_camera", () => {
-      this._initCamera();
-      this.redrawRequest();
-    });
 
     // mouse events
     this._main.contextmenu((e) => {

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -465,7 +465,11 @@ class PCDLabelTool extends React.Component {
     zPlane.rotation.order = 'ZXY';
     this._zPlane = zPlane;
 
-
+    // Register key commands
+    addKeyCommand("reset_camera", () => {
+      this._initCamera();
+      this.redrawRequest();
+    });
 
     // mouse events
     this._main.contextmenu((e) => {


### PR DESCRIPTION
## What?

- 0キーでカメラ位置を初期化する機能を追加
- OrbitControlsの `saveState()` を呼んでから `reset()` を呼ぶと、 `saveState()` を呼んだときのカメラパラメータに戻せる機能を利用

## Why?

以前のバージョンにあったもの

## See also [Optional]

- カメラのリセット方法
  - https://stackoverflow.com/a/29991405
- OrbitControls.saveState のドキュメント
  - https://threejs.org/docs/index.html#examples/en/controls/OrbitControls.saveState

## Screenshot or video [Optional]
