### PR TITLE
Add rotate camera with 9 key

### DIFF
--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -9,8 +9,20 @@ export const keymapDefault = [
     "command": "reset_camera",
   },
   {
+    "keys": ["Digit6"],
+    "command": "rotate_camera_rear",
+  },
+  {
+    "keys": ["Digit7"],
+    "command": "rotate_camera_left",
+  },
+  {
+    "keys": ["Digit8"],
+    "command": "rotate_camera_front",
+  },
+  {
     "keys": ["Digit9"],
-    "command": "rotate_camera",
+    "command": "rotate_camera_right",
   },
 
   // history

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -8,6 +8,10 @@ export const keymapDefault = [
     "keys": ["Digit0"],
     "command": "reset_camera",
   },
+  {
+    "keys": ["Digit9"],
+    "command": "rotate_camera",
+  },
 
   // history
   {

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -92,7 +92,6 @@ class PCDLabelTool extends React.Component {
   _renderer = null;
   _camera = null;
   _cameraControls = null;
-  _camera_rotate_state = 0;
   //cameraExMat = new THREE.Matrix4();
   // PCD objects
   _pcdLoader = null;
@@ -251,30 +250,24 @@ class PCDLabelTool extends React.Component {
         // Reset camera potision to when saveState called
         this._cameraControls.reset();
         this.redrawRequest();
-
-        // Reset camera rotate state
-        this._camera_rotate_state = 0;
       });
-      execKeyCommand("rotate_camera", e.originalEvent, () => {
-        switch (this._camera_rotate_state) {
-          case 0:
-            this._camera.position.set(-1000, 0, 0);
-            this._camera_rotate_state = 1;
-            break;
-          case 1:
-            this._camera.position.set(0, 1000, 0);
-            this._camera_rotate_state = 2;
-            break;
-          case 2:
-            this._camera.position.set(1000, 0, 0);
-            this._camera_rotate_state = 3;
-            break;
-          case 3:
-            this._camera.position.set(0, -1000, 0);
-            this._camera_rotate_state = 0;
-            break;
-        }
-
+      execKeyCommand("rotate_camera_rear", e.originalEvent, () => {
+        this._camera.position.set(-1000, 0, 0);
+        this._cameraControls.update();
+        this.redrawRequest();
+      });
+      execKeyCommand("rotate_camera_left", e.originalEvent, () => {
+        this._camera.position.set(0, 1000, 0);
+        this._cameraControls.update();
+        this.redrawRequest();
+      });
+      execKeyCommand("rotate_camera_front", e.originalEvent, () => {
+        this._camera.position.set(1000, 0, 0);
+        this._cameraControls.update();
+        this.redrawRequest();
+      });
+      execKeyCommand("rotate_camera_right", e.originalEvent, () => {
+        this._camera.position.set(0, -1000, 0);
         this._cameraControls.update();
         this.redrawRequest();
       });

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -92,6 +92,7 @@ class PCDLabelTool extends React.Component {
   _renderer = null;
   _camera = null;
   _cameraControls = null;
+  _camera_rotate_state = 0;
   //cameraExMat = new THREE.Matrix4();
   // PCD objects
   _pcdLoader = null;
@@ -249,6 +250,32 @@ class PCDLabelTool extends React.Component {
       execKeyCommand("reset_camera", e.originalEvent, () => {
         // Reset camera potision to when saveState called
         this._cameraControls.reset();
+        this.redrawRequest();
+
+        // Reset camera rotate state
+        this._camera_rotate_state = 0;
+      });
+      execKeyCommand("rotate_camera", e.originalEvent, () => {
+        switch (this._camera_rotate_state) {
+          case 0:
+            this._camera.position.set(-1000, 0, 0);
+            this._camera_rotate_state = 1;
+            break;
+          case 1:
+            this._camera.position.set(0, 1000, 0);
+            this._camera_rotate_state = 2;
+            break;
+          case 2:
+            this._camera.position.set(1000, 0, 0);
+            this._camera_rotate_state = 3;
+            break;
+          case 3:
+            this._camera.position.set(0, -1000, 0);
+            this._camera_rotate_state = 0;
+            break;
+        }
+
+        this._cameraControls.update();
         this.redrawRequest();
       });
     },


### PR DESCRIPTION
## What?

- 9キーで真横からの視点に変更する機能を追加
- 押すごとに真横からの4方向にカメラを切替

## Why?

以前作った機能の復活

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

![画面収録 2020-08-13 20 49 16](https://user-images.githubusercontent.com/13210107/90131372-fe5c6880-dda6-11ea-880d-1d5e1b91fdc6.gif)
