### PR TITLE
Fix centering of label color in tabs

### DIFF
--- a/front/app/labeling_tool/klass_set.js
+++ b/front/app/labeling_tool/klass_set.js
@@ -106,7 +106,7 @@ class KlassSet extends React.Component {
             <div>
               <div
                 className={classes.colorPane}
-                style={{ backgroundColor: klass.color }}
+                style={{ backgroundColor: klass.color, margin: 'auto' }}
               />
               {klass.name}
             </div>


### PR DESCRIPTION
## What?

- クラスを選択するタブのラベルの部分が左寄せになっていたため、中央揃えに変更

## Why?

左寄せなのが気になる

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

### 修正前
<img width="1047" alt="スクリーンショット 2020-08-14 14 58 12" src="https://user-images.githubusercontent.com/13210107/90218453-cd2f7700-de3e-11ea-88b2-0539f1183efb.png">

### 修正後
<img width="964" alt="スクリーンショット 2020-08-14 14 56 14" src="https://user-images.githubusercontent.com/13210107/90218447-c9035980-de3e-11ea-91e1-b56b9813531d.png">



