### PR TITLE
Add keymap to select next/prev bbox

### DIFF
--- a/front/app/labeling_tool/annotation.js
+++ b/front/app/labeling_tool/annotation.js
@@ -189,11 +189,31 @@ class Annotation extends React.Component {
   getTarget() {
     return this.props.targetLabel;
   }
-  getNextTarget() {
-    if(this.props.targetLabel){
-      const curInstanceId = this.props.targetLabel.instanceId
-      console.log("curInstanceId", curInstanceId)
+  getNthTarget(n){
+    const labels = new Map(this.state.labels)
+    const targetLabel = this.props.targetLabel
+    const idList = Array.from(labels.keys())
+    if(idList.length < 1){
+      return(null)
     }
+    if(n > 0){
+      var nextLabelIndex = (idList.length + n - 1) % idList.length
+    }else{
+      var nextLabelIndex = (idList.length + n) % idList.length
+    }
+    if(targetLabel){
+      const curLabelIndex = idList.findIndex(x => x === targetLabel.id)
+      nextLabelIndex = (idList.length + curLabelIndex + n) % (idList.length)
+    }
+    return labels.get(idList[nextLabelIndex])
+  }
+  getPrevTarget() {
+    const prevTarget = this.getNthTarget(-1)
+    this.setTarget(prevTarget)
+  }
+  getNextTarget() {
+    const nextTarget = this.getNthTarget(1)
+    this.setTarget(nextTarget)
   }
   setTarget(tgt) { /** Label */ 
     let next = this.getLabel(tgt),

--- a/front/app/labeling_tool/annotation.js
+++ b/front/app/labeling_tool/annotation.js
@@ -189,7 +189,13 @@ class Annotation extends React.Component {
   getTarget() {
     return this.props.targetLabel;
   }
-  setTarget(tgt) {
+  getNextTarget() {
+    if(this.props.targetLabel){
+      const curInstanceId = this.props.targetLabel.instanceId
+      console.log("curInstanceId", curInstanceId)
+    }
+  }
+  setTarget(tgt) { /** Label */ 
     let next = this.getLabel(tgt),
       prev = this.props.targetLabel;
     if (prev != null && next != null && next.id === prev.id) {

--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -205,6 +205,9 @@ class Controls extends React.Component {
         execKeyCommand("select_next_bbox", e.originalEvent, () => {
           this.props.annotation.getNextTarget()
         })
+        execKeyCommand("select_prev_bbox", e.originalEvent, () => {
+          this.props.annotation.getPrevTarget()
+        })
 
         this.getTool().handles.keydown(e);
       })

--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -134,6 +134,7 @@ class Controls extends React.Component {
         if (this.state.isLoading) {
           return;
         }
+
         const targetLabel = this.props.annotation.getTarget()
         if(targetLabel){
           if(targetLabel.bbox){
@@ -200,6 +201,10 @@ class Controls extends React.Component {
         })
         execKeyCommand("bbox_copy", e.originalEvent, () => this.props.clipboard.copy(null))
         execKeyCommand("bbox_paste", e.originalEvent, () => this.props.clipboard.paste())
+
+        execKeyCommand("select_next_bbox", e.originalEvent, () => {
+          this.props.annotation.getNextTarget()
+        })
 
         this.getTool().handles.keydown(e);
       })

--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -208,6 +208,9 @@ class Controls extends React.Component {
         execKeyCommand("select_prev_bbox", e.originalEvent, () => {
           this.props.annotation.getPrevTarget()
         })
+        execKeyCommand("deselect_bbox", e.originalEvent, () => {
+          this.props.annotation.setTarget(null)
+        })
 
         this.getTool().handles.keydown(e);
       })

--- a/front/app/labeling_tool/key_control/index.js
+++ b/front/app/labeling_tool/key_control/index.js
@@ -15,7 +15,6 @@ export const addKeyCommand = (command, callback) => {
     }else{
       objBind.keys.forEach((objKey) => {
         const lits = objKey.split("+")
-        // TODO: only shift
         const m = {
           altKey:   lits.includes(modifiers.altKey),
           ctrlKey:  lits.includes(modifiers.ctrlKey),

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -39,6 +39,10 @@ export const keymapDefault = [
     "keys": ["ctrl+KeyV", "meta+KeyV"],
     "command": "bbox_paste",
   },
+  {
+    "keys": ["KeyJ"],
+    "command": "select_next_bbox",
+  },
 
   // move
   {

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -47,6 +47,10 @@ export const keymapDefault = [
     "keys": ["KeyK"],
     "command": "select_prev_bbox",
   },
+  {
+    "keys": ["Escape"],
+    "command": "deselect_bbox",
+  },
 
   // move
   {

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -43,6 +43,10 @@ export const keymapDefault = [
     "keys": ["KeyJ"],
     "command": "select_next_bbox",
   },
+  {
+    "keys": ["KeyK"],
+    "command": "select_prev_bbox",
+  },
 
   // move
   {


### PR DESCRIPTION
## What?
- 前後の bbox を選択できるキーマップ(KeyJ, KeyK)を作成した

## Why?
- 仕様を満たすため

## See also [Optional]
https://www.notion.so/humandatawarelab/Automan-a6a855b8e1c5465386c164bdf381ef7c

## Screenshot or video [Optional]
![20200815](https://user-images.githubusercontent.com/8692594/90307145-ac365700-df0e-11ea-822f-299959f89761.gif)
