### PR TITLE
Fix the bug that labeling-tool does not work when topics to extract are limited

### DIFF
--- a/automan/api/projects/datasets/dataset_manager.py
+++ b/automan/api/projects/datasets/dataset_manager.py
@@ -101,6 +101,15 @@ class DatasetManager(object):
         contents['frame_count'] = dataset.frame_count
         contents['created_at'] = str(dataset.created_at)
         contents['updated_at'] = str(dataset.updated_at)
+
+        # Get candidates
+        dataset_candidates = DatasetDatasetCandidate.objects.filter(dataset=dataset)
+        if dataset_candidates is None:
+            candidates = []
+        else:
+            candidates = [c.dataset_candidate_id for c in dataset_candidates]
+        contents['candidates'] = candidates
+
         return contents
 
     def get_dataset_file_path(self, user_id, dataset_id):

--- a/front/app/labeling_tool/base_label_tool.jsx
+++ b/front/app/labeling_tool/base_label_tool.jsx
@@ -232,6 +232,7 @@ class LabelTool extends React.Component {
         res => {
           this.originalId = res.original_id;
           this.frameLength = res.frame_count;
+          this.datasetCandidateIds = res.candidates;
           resolve();
         },
         err => {
@@ -246,7 +247,9 @@ class LabelTool extends React.Component {
         this.getURL('candidate_info'),
         null,
         res => {
-          this.candidateInfo = res.records;
+          this.candidateInfo = res.records.filter((item) => {
+            return this.datasetCandidateIds.includes(item.candidate_id);
+          });
 
           resolve();
         },


### PR DESCRIPTION
## What?
一部のトピックしか抽出していないデータセットでラベリングツールが使えないバグを修正

## Why?
バグ修正のため