### PR TITLE
Add a panel for controlling parameters for visualizing points

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -35,7 +35,8 @@ class PCDLabelTool extends React.Component {
         controllerMaxValue: 10,
         minValue: -5,
         maxValue: 5
-      }
+      },
+      visualizeObjectIds: false
     };
     this._wrapperElement = React.createRef();
     this._mainElement = React.createRef();

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -281,13 +281,16 @@ export default class PCDBBox {
   }
   updateText() {
     this.removeText();
-    const newText = this.generateTextMesh();
-    const box = this.box;
-    this.pcdTool._scene.add(newText);
-    newText.position.set(box.pos.x, box.pos.y, box.pos.z);
-    newText.rotation.z = box.yaw - 1.57;
-    newText.updateMatrixWorld();
-    this.cube.text = newText;
+    if (this.pcdTool.state.visualizeObjectIds) {
+      const newText = this.generateTextMesh();
+      const box = this.box;
+      this.pcdTool._scene.add(newText);
+      newText.position.set(box.pos.x, box.pos.y, box.pos.z);
+      newText.scale.set(Math.min(box.size.x, box.size.y) / 2, Math.min(box.size.x, box.size.y) / 2, box.size.z);
+      newText.rotation.z = box.yaw - 1.57;
+      newText.updateMatrixWorld();
+      this.cube.text = newText;
+    }
   }
   setObjectId(id){
     const box = this.box;

--- a/front/app/labeling_tool/pcd_tool/view_controller.jsx
+++ b/front/app/labeling_tool/pcd_tool/view_controller.jsx
@@ -1,0 +1,158 @@
+import React from 'react';
+
+import {
+  InputLabel,
+  MenuItem,
+  Select,
+  Slider,
+  Typography
+} from '@material-ui/core';
+
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+
+class ViewController extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      pointColoringRange: [
+        this.props.tool.state.pointColoringSettings.minValue,
+        this.props.tool.state.pointColoringSettings.maxValue
+      ]
+    };
+  }
+
+  updateMeshMaterialSettings = (settings) => {
+    this.props.tool.updateMeshMaterialSettings(settings, ()=>{
+      this.forceUpdate();
+    });
+  }
+
+  updatePointColoringSettings = (settings) => {
+    this.props.tool.updatePointColoringSettings(settings, ()=>{
+      this.forceUpdate();
+    });
+  }
+
+  pointColoringControllerMinMax = (axis) => {
+    switch (axis) {
+      case "x":
+        return {
+          controllerMinValue: -100,
+          controllerMaxValue: 100,
+        }
+      case "y":
+        return {
+          controllerMinValue: -10,
+          controllerMaxValue: 10,
+        }
+      case "z":
+        return {
+          controllerMinValue: -5,
+          controllerMaxValue: 10,
+        }
+      case "distance":
+        return {
+          controllerMinValue: -100,
+          controllerMaxValue: 100,
+        }
+      default:
+        return {
+          controllerMinValue: -10,
+          controllerMaxValue: 10,
+        }
+    }
+  }
+
+  render() {
+    return (
+     <div style={{width: "100%", display: "block"}}>
+      <div style={{margin: "0 16px"}}>
+        <Typography id="view-controller-point-size" gutterBottom>
+          Point-size:
+        </Typography>
+        <Slider
+          defaultValue={0.05}
+          getAriaValueText={(value) => {return `${value}`}}
+          aria-labelledby="view-controller-point-size"
+          step={0.01}
+          marks
+          min={0.01}
+          max={0.5}
+          valueLabelDisplay="auto"
+          value={this.props.tool.state.meshMaterialSettings.size}
+          onChange={(event, value) => {
+            this.updateMeshMaterialSettings({
+              size: value
+            })
+          }}
+        />
+        <InputLabel id="point-coloring-axis-label">Coloring axis:</InputLabel>
+        <Select
+          labelId="point-coloring-axis-label"
+          id="point-coloring-axis"
+          value={this.props.tool.state.pointColoringSettings.axis}
+          onChange={(event, value) => {
+            const axis = event.target.value;
+            this.updatePointColoringSettings({
+              axis: axis,
+              ...this.pointColoringControllerMinMax(axis)
+            })
+          }}
+        >
+          <MenuItem value={'none'}>none</MenuItem>
+          <MenuItem value={'x'}>x</MenuItem>
+          <MenuItem value={'y'}>y</MenuItem>
+          <MenuItem value={'z'}>z</MenuItem>
+          <MenuItem value={'distance'}>distance</MenuItem>
+        </Select>
+        {this.props.tool.state.pointColoringSettings.axis !== "none" &&
+        <div>
+        <Typography id="point-coloring-min-max" gutterBottom>
+          Range:
+        </Typography>
+        <Slider
+          getAriaValueText={(value) => {return `${value}m`}}
+          aria-labelledby="point-coloring-min-max"
+          min={this.props.tool.state.pointColoringSettings.controllerMinValue}
+          max={this.props.tool.state.pointColoringSettings.controllerMaxValue}
+          valueLabelDisplay="auto"
+          value={this.state.pointColoringRange}
+          onChange={(event, value) => {
+            this.setState({
+              pointColoringRange: value
+            })
+          }}
+          onChangeCommitted={() => {
+            this.updatePointColoringSettings({
+              minValue: this.state.pointColoringRange[0],
+              maxValue: this.state.pointColoringRange[1],
+            })
+          }}
+        />
+        </div>
+        }
+      </div>
+    </div>
+    );
+  }
+}
+const mapStateToProps = (state, ownProps) => {
+  const { candidateId } = ownProps
+  const correspondingTools = state.tool.tools.filter((item) => {
+    return item.candidateId === candidateId
+  });
+  if (correspondingTools.length !== 1) {
+    throw 'No corresponding tool found';
+  }
+  return {
+    tool: correspondingTools[0],
+  }
+};
+export default compose(
+  connect(
+    mapStateToProps,
+    null
+  )
+)(ViewController)
+

--- a/front/app/labeling_tool/pcd_tool/view_controller.jsx
+++ b/front/app/labeling_tool/pcd_tool/view_controller.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
 import {
+  Checkbox,
+  FormControlLabel,
   InputLabel,
   MenuItem,
   Select,
@@ -68,6 +70,25 @@ class ViewController extends React.Component {
     return (
      <div style={{width: "100%", display: "block"}}>
       <div style={{margin: "0 16px"}}>
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={this.props.tool.state.visualizeObjectIds}
+              onChange={(event) => {
+                this.props.tool.setState({
+                  visualizeObjectIds: event.target.checked
+                }, () => {
+                  this.props.tool.pcdBBoxes.forEach((item)=>{item.updateText()});
+                  this.props.tool.redrawRequest();
+                  this.forceUpdate();
+                })
+              }}
+              name="show-object-ids"
+              color="primary"
+            />
+          }
+          label="Show Object-ids"
+        />
         <Typography id="view-controller-point-size" gutterBottom>
           Point-size:
         </Typography>

--- a/front/app/labeling_tool/tool-style.js
+++ b/front/app/labeling_tool/tool-style.js
@@ -9,7 +9,7 @@ import grey from '@material-ui/core/colors/grey';
 export const appBarHeight = 54;
 // sidebar status
 export const drawerWidth = 160;
-const toolHeight = 350;
+const toolHeight = 450;
 const listHead = 20;
 export const toolStyle = theme => ({
   drawer: {


### PR DESCRIPTION
## What?
- 点群の可視化に関するパラメータを調整するためのパネルを追加
- bbox上の数字のサイズをbboxのサイズに合わせるように変更
- bbox上の数字の表示・非表示を切り替えるトグルを追加

## Why?
使い勝手の向上のため

## See also [Optional]
https://www.notion.so/humandatawarelab/Automan-4020ad2f817a4d7b93577b4fd5d6ccb2
https://www.notion.so/humandatawarelab/Automan-object_id-3e02400bdb974fd1a126e8213f7d358a

## Screenshot or video [Optional]
![screencast](https://user-images.githubusercontent.com/24401842/90985950-368b5480-e5ba-11ea-8bee-1352ede1ccc3.gif)

![Screenshot from 2020-08-24 11-27-48](https://user-images.githubusercontent.com/24401842/90997702-3bbdc300-e5fd-11ea-99cc-ad4c653940ce.png)

