### PR TITLE
Add feature to project 3D-boxes onto 2D-images

### DIFF
--- a/front/app/labeling_tool/base_label_tool.jsx
+++ b/front/app/labeling_tool/base_label_tool.jsx
@@ -96,7 +96,7 @@ class LabelTool extends React.Component {
         ret = DATASET_ROOT;
         break;
       case 'calibrations':
-        ret = PROJECT_ROOT + 'calibrations/';
+        ret = PROJECT_ROOT + 'calibrations/?per_page=100';
         break;
       case 'candidate_info': {
         const dataType = args[0];

--- a/front/app/labeling_tool/pcd_tool/bbox_projector.js
+++ b/front/app/labeling_tool/pcd_tool/bbox_projector.js
@@ -1,0 +1,74 @@
+const project3DPoint = (calibrationFile, x_3d, y_3d, z_3d) => {
+  const distCoeff = calibrationFile.calibration.dist_coeff[0];
+  const k1 = distCoeff[0];
+  const k2 = distCoeff[1];
+  const t1 = distCoeff[2];
+  const t2 = distCoeff[3];
+  const k3 = distCoeff[4];
+  const mul = calibrationFile.cameraExtrinsicMatrix.elements;
+  const X = x_3d - mul[12];
+  const Y = y_3d - mul[13];
+  const Z = z_3d - mul[14];
+  const x = mul[0] * X + mul[1] * Y + mul[2] * Z;
+  const y = mul[4] * X + mul[5] * Y + mul[6] * Z;
+  const z = mul[8] * X + mul[9] * Y + mul[10] * Z;
+  const x1 = x / z;
+  const y1 = y / z;
+  const r = Math.pow(x1, 2) + Math.pow(y1, 2);
+  const radialDistCoeff = 1 + k1 * Math.pow(r, 2) + k2 * Math.pow(r, 4) + k3 * Math.pow(r, 6);
+  const x2 = x1 * radialDistCoeff + 2 * t1 * x1 * y1 + t2 * (Math.pow(r, 2) + 2 * Math.pow(x1, 2));
+  const y2 = y1 * radialDistCoeff + t1 * (Math.pow(r, 2) + 2 * Math.pow(y1, 2)) + 2 * t2 * x1 * y1;
+  const cameraMat = calibrationFile.calibration.camera_mat;
+  const u = cameraMat[0][0] * x2 + cameraMat[0][2];
+  const v = cameraMat[1][1] * y2 + cameraMat[1][2];
+  return {
+    u: u,
+    v: v,
+    w: z,
+  }
+}
+
+
+const projectBBox = (calibrationFile, box) => {
+  const x_2 = box.size.x / 2;
+  const y_2 = box.size.y / 2;
+  const z_2 = box.size.z / 2;
+  const cornerPointBases = [
+    [x_2, y_2, z_2],
+    [x_2, -y_2, z_2],
+    [-x_2, -y_2, z_2],
+    [-x_2, y_2, z_2],
+    [x_2, y_2, -z_2],
+    [x_2, -y_2, -z_2],
+    [-x_2, -y_2, -z_2],
+    [-x_2, y_2, -z_2]
+  ];
+  const cornerPoints = cornerPointBases.map((p) => {
+    return [
+      box.pos.x + Math.cos(box.yaw) * p[0] - Math.sin(box.yaw) * p[1] + 0 * p[2],
+      box.pos.y + Math.sin(box.yaw) * p[0] + Math.cos(box.yaw) * p[1] + 0 * p[2],
+      box.pos.z + 0 * p[0] + 0 * p[1] + 1 * p[2]
+    ]
+  })
+
+  let projectedBox = project3DPoint(calibrationFile, box.pos.x, box.pos.y, box.pos.z);
+  const projectedCornerPoints = cornerPoints.map((points) => {
+    return project3DPoint(calibrationFile, ...points);
+  })
+  projectedBox = {
+    ...projectedBox,
+    u_min: Math.min(...projectedCornerPoints.map((item) => {return item.u})),
+    u_max: Math.max(...projectedCornerPoints.map((item) => {return item.u})),
+    v_min: Math.min(...projectedCornerPoints.map((item) => {return item.v})),
+    v_max: Math.max(...projectedCornerPoints.map((item) => {return item.v})),
+    w_min: Math.min(...projectedCornerPoints.map((item) => {return item.w})),
+    w_max: Math.max(...projectedCornerPoints.map((item) => {return item.w})),
+    cornerPoints: cornerPoints,
+    projectedCornerPoints: projectedCornerPoints,
+    box: box,
+  }
+
+  return projectedBox;
+}
+
+export default projectBBox;

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -1,10 +1,38 @@
 import BoxFrameObject from './box_frame_object';
+import projectBBox from './bbox_projector';
 
 const BBoxParams = {
   geometry: new THREE.CubeGeometry(1.0, 1.0, 1.0),
   material: new THREE.MeshBasicMaterial({
     color: 0x008866,
-  })
+  }),
+  // attrs: {
+  //   rect: {
+  //     'stroke': 'red',
+  //     'stroke-width': 10,
+  //     'fill': '#fff',
+  //     'fill-opacity': 0,
+  //     'cursor': 'all-scroll'
+  //   }
+  // }
+  attrs: {
+    rect: {
+      selected: {
+        'stroke': 'red',
+        'stroke-width': 10,
+        'fill': '#fff',
+        'fill-opacity': 0,
+        'cursor': 'all-scroll'
+      },
+      normal: {
+        'stroke': '#086',
+        'stroke-width': 6,
+        'fill': '#fff',
+        'fill-opacity': 0,
+        'cursor': 'all-scroll'
+      },
+    }
+  }
 };
 const ZERO2 = new THREE.Vector2(0, 0);
 const EDIT_OBJ_SIZE = 0.5;
@@ -20,6 +48,7 @@ export default class PCDBBox {
       yaw: 0,
       objectId: 0,
     };
+    this.projectedRects = {};
     if (content != null) {
       // init parameters
       this.fromContent(content);
@@ -70,6 +99,15 @@ export default class PCDBBox {
     this.cube.meshFrame.setBold(selected);
     const box = this.box;
     this.cube.meshFrame.setParam(box.pos, box.size, box.yaw);
+
+    // Update projected rects
+    Object.values(this.projectedRects).forEach((rect) => {
+      if (selected) {
+        rect.attr(BBoxParams.attrs.rect.selected);
+      }else {
+        rect.attr(BBoxParams.attrs.rect.normal);
+      }
+    });
   }
   hover(isInto) {
     this.cube.meshFrame.setStatus(this.selected, isInto);
@@ -89,6 +127,7 @@ export default class PCDBBox {
     const group = this.cube.editGroup;
     this.pcdTool._scene.remove(group);
     this.removeText();
+    this.removeProjectedRects();
     this.pcdTool.redrawRequest();
     this.pcdTool.pcdBBoxes.delete(this);
   }
@@ -258,6 +297,7 @@ export default class PCDBBox {
     zFace[1].position.set(0, 0, -box.size.z/2-w/2);
     zFace[1].scale.set(box.size.x, box.size.y, w);
     this.updateText();
+    this.update2DBox();
     if ( changed ) {
       this.label.isChanged = true;
     }
@@ -291,6 +331,50 @@ export default class PCDBBox {
       newText.updateMatrixWorld();
       this.cube.text = newText;
     }
+  }
+  removeProjectedRects() {
+    Object.values(this.projectedRects).forEach((rect) => {
+      rect.remove();
+    });
+  }
+  update2DBox() {
+    if (!this.pcdTool
+      || !this.pcdTool.props
+      || !this.pcdTool.props.labelTool
+      || !this.pcdTool.props.labelTool.calibrations
+      || !this.pcdTool.props.labelTool.candidateCalibrations
+    ) {
+      return
+    }
+    this.removeProjectedRects();
+    Object.entries(this.pcdTool.props.labelTool.candidateCalibrations).forEach(([key, value]) => {
+      const candidateId = Number(key);
+      const calibrationFiles = this.pcdTool.props.labelTool.calibrations.filter((item) => {
+        return item.id === value
+      })
+      if (calibrationFiles.length !== 1) return;
+
+      // Project the box to the corresponding 2D image
+      const projectedBox = projectBBox(calibrationFiles[0], this.box);
+      if (projectedBox.w < 0) return;
+
+      const imageTool = this.pcdTool.props.controls.getToolFromCandidateId(candidateId);
+      const width = projectedBox.u_max - projectedBox.u_min;
+      const height = projectedBox.v_max - projectedBox.v_min;
+      const rect = imageTool._paper.rect(
+        projectedBox.u_min, projectedBox.v_min,
+        width, height
+      );
+
+      if (this.selected) {
+        rect.attr(BBoxParams.attrs.rect.selected);
+      }
+      else {
+        rect.attr(BBoxParams.attrs.rect.normal);
+      }
+
+      this.projectedRects[key] = rect;
+    }, this);
   }
   setObjectId(id){
     const box = this.box;


### PR DESCRIPTION
## What?
3Dバウンディングボックスを2D画像上に投影する機能を追加

## Why?
画像と点群の位置関係を把握しやすくするため

## See also [Optional]
https://www.notion.so/humandatawarelab/Automan-3D-2D-fa773058d19f411e923563d9fd68a7c9

## Screenshot or video [Optional]
![screencast](https://user-images.githubusercontent.com/24401842/91213813-1f30a080-e74d-11ea-938c-f1c862ec7174.gif)
