### PR TITLE
Fix the bug that klass-tab was not scrollable

### DIFF
--- a/front/app/labeling_tool/klass_set.js
+++ b/front/app/labeling_tool/klass_set.js
@@ -126,6 +126,8 @@ class KlassSet extends React.Component {
       <Tabs
         value={this.state.targetIndex}
         onChange={this.handleTabChange}
+        variant="scrollable"
+        scrollButtons="auto"
       >
         {this.renderTabs(classes)}
       </Tabs>


### PR DESCRIPTION
## What?
ラベリングツール画面上部のクラス一覧の部分がスクロールできないバグを修正

## Why?
クラス数が多くてもすべて表示できるようにするため