### PR TITLE
Fix left side bar layout

### DIFF
--- a/front/app/labeling_tool/tool-style.js
+++ b/front/app/labeling_tool/tool-style.js
@@ -9,7 +9,7 @@ import grey from '@material-ui/core/colors/grey';
 export const appBarHeight = 54;
 // sidebar status
 export const drawerWidth = 160;
-const toolHeight = 700;
+const labelListHeight = 200;
 const listHead = 20;
 export const toolStyle = theme => ({
   drawer: {
@@ -61,14 +61,17 @@ export const toolStyle = theme => ({
   toolControlsWrapper: {
   },
   toolControls: {
-    height: toolHeight,
-    textAlign: 'center'
+    height: `calc(100vh - ${appBarHeight}px - ${labelListHeight}px)`,
+    paddingBottom: '1rem',
+    textAlign: 'center',
+    overflowY: 'scroll',
   },
   activeTool: {
     backgroundColor: 'rgba(0, 0, 0, 0.2)'
   },
   labelList: {
-    height: `calc(100vh - ${appBarHeight}px - ${toolHeight}px)`
+    height: labelListHeight,
+    padding: 0,
   },
   klassSetList: {
     textAlign: 'center',


### PR DESCRIPTION
## What?

- 左バーのラベル一覧が上のコントロールと被ってしまうバグを修正
- ラベルリストの高さを固定して、100vhからナブバーとラベルリスト高さを引いた残りをコントロールに割り当てた

## Why?

レイアウトのバグ

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

![画面収録 2020-08-27 14 08 00](https://user-images.githubusercontent.com/13210107/91387029-42537100-e86f-11ea-8b8c-9acf5ed67fab.gif)
