### PR TITLE
Add bbox info on editing

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -36,6 +36,7 @@ class PCDLabelTool extends React.Component {
         maxValue: 5
       },
       visualizeObjectIds: false,
+      visualizeBoxInfo: true,
       cameraHelperSettings: {
         isUpdating: false,
         visible: true,

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -377,7 +377,7 @@ export default class PCDBBox {
   updateBoxInfoTextMesh () {
     this.removeBoxInfoTextMesh();
 
-    if (this.selected) {
+    if (this.selected && this.pcdTool.state.visualizeBoxInfo) {
       const newboxInfoText = this.generateBoxInfoTextMesh();
       const box = this.box;
       this.pcdTool._scene.add(newboxInfoText);

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -381,7 +381,7 @@ export default class PCDBBox {
       const newboxInfoText = this.generateBoxInfoTextMesh();
       const box = this.box;
       this.pcdTool._scene.add(newboxInfoText);
-      newboxInfoText.position.set(box.pos.x + box.size.x / 2, box.pos.y - box.size.y / 2 - 0.2, box.pos.z);
+      newboxInfoText.position.set(box.pos.x + box.size.x / 2 - 0.4, box.pos.y - box.size.y / 2 - 0.6, box.pos.z);
       newboxInfoText.rotation.z = - 1.57;
       newboxInfoText.updateMatrixWorld();
       this.cube.boxInfoText = newboxInfoText;

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -275,14 +275,14 @@ export default class PCDBBox {
       + `size_x: ${this.box.size.x.toFixed(2)}\n`
       + `size_y: ${this.box.size.y.toFixed(2)}\n`
       + `size_z: ${this.box.size.z.toFixed(2)}`;
-    const shapes = this.pcdTool._font.generateShapes(message, 1);
+    const shapes = this.pcdTool._font.generateShapes(message, 0.7);
     const geometry = new THREE.ShapeBufferGeometry(shapes);
     geometry.computeBoundingBox();
     geometry.translate(0, 0, 1.0);
     let text = new THREE.Mesh(geometry, matDark);
     text.visible = true;
     text.rotation.z = -1.57;
-    text.scale.set(0.1, 0.1, 0.1);
+    text.scale.set(1, 1, 1);
     return text;
   }
   updateCube(changed) {
@@ -381,8 +381,7 @@ export default class PCDBBox {
       const newboxInfoText = this.generateBoxInfoTextMesh();
       const box = this.box;
       this.pcdTool._scene.add(newboxInfoText);
-      newboxInfoText.position.set(box.pos.x, box.pos.y, box.pos.z);
-      newboxInfoText.scale.set(Math.min(box.size.x, box.size.y) / 2, Math.min(box.size.x, box.size.y) / 2, box.size.z);
+      newboxInfoText.position.set(box.pos.x + box.size.x / 2, box.pos.y - box.size.y / 2 - 0.2, box.pos.z);
       newboxInfoText.rotation.z = - 1.57;
       newboxInfoText.updateMatrixWorld();
       this.cube.boxInfoText = newboxInfoText;

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -99,6 +99,8 @@ export default class PCDBBox {
     this.cube.meshFrame.setBold(selected);
     const box = this.box;
     this.cube.meshFrame.setParam(box.pos, box.size, box.yaw);
+    // Update mesh
+    this.updateBoxInfoTextMesh();
 
     // Update projected rects
     Object.values(this.projectedRects).forEach((rect) => {
@@ -213,6 +215,8 @@ export default class PCDBBox {
     this.pcdTool._scene.add(group);
     const text = this.generateTextMesh();
     this.pcdTool._scene.add(text);
+    const boxInfoText = this.generateBoxInfoTextMesh();
+    this.pcdTool._scene.add(boxInfoText);
 
     this.cube = {
       mesh: mesh,
@@ -221,7 +225,8 @@ export default class PCDBBox {
       edges: edges,
       zFace: zFace,
       editGroup: group,
-      text: text
+      text: text,
+      boxInfoText: boxInfoText,
     };
     this.updateCube(false);
   }
@@ -256,6 +261,28 @@ export default class PCDBBox {
     text.add(text_backside);
     text.rotation.z = -1.57;
     text.scale.set(1, 1, 1);
+    return text;
+  }
+  generateBoxInfoTextMesh () {
+    const color = "#FFFFFF";
+    const matDark = new THREE.LineBasicMaterial({
+      color: color,
+      side: THREE.DoubleSide,
+    });
+    const message = `pos_x: ${this.box.pos.x.toFixed(2)}\n`
+      + `pos_y: ${this.box.pos.y.toFixed(2)}\n`
+      + `pos_z: ${this.box.pos.z.toFixed(2)}\n`
+      + `size_x: ${this.box.size.x.toFixed(2)}\n`
+      + `size_y: ${this.box.size.y.toFixed(2)}\n`
+      + `size_z: ${this.box.size.z.toFixed(2)}`;
+    const shapes = this.pcdTool._font.generateShapes(message, 1);
+    const geometry = new THREE.ShapeBufferGeometry(shapes);
+    geometry.computeBoundingBox();
+    geometry.translate(0, 0, 1.0);
+    let text = new THREE.Mesh(geometry, matDark);
+    text.visible = true;
+    text.rotation.z = -1.57;
+    text.scale.set(0.1, 0.1, 0.1);
     return text;
   }
   updateCube(changed) {
@@ -296,6 +323,7 @@ export default class PCDBBox {
     zFace[0].scale.set(box.size.x, box.size.y, w);
     zFace[1].position.set(0, 0, -box.size.z/2-w/2);
     zFace[1].scale.set(box.size.x, box.size.y, w);
+    this.updateBoxInfoTextMesh();
     this.updateText();
     this.update2DBox();
     if ( changed ) {
@@ -330,6 +358,34 @@ export default class PCDBBox {
       newText.rotation.z = box.yaw - 1.57;
       newText.updateMatrixWorld();
       this.cube.text = newText;
+    }
+  }
+  removeBoxInfoTextMesh () {
+    if (!("boxInfoText" in this.cube)) {
+      return
+    }
+    const boxInfoText = this.cube.boxInfoText;
+    boxInfoText.children.forEach((child) => {
+      boxInfoText.remove(child);
+      child.geometry.dispose();
+      child.material.dispose();
+    }, boxInfoText)
+    this.pcdTool._scene.remove(boxInfoText);
+    boxInfoText.geometry.dispose();
+    boxInfoText.material.dispose();
+  }
+  updateBoxInfoTextMesh () {
+    this.removeBoxInfoTextMesh();
+
+    if (this.selected) {
+      const newboxInfoText = this.generateBoxInfoTextMesh();
+      const box = this.box;
+      this.pcdTool._scene.add(newboxInfoText);
+      newboxInfoText.position.set(box.pos.x, box.pos.y, box.pos.z);
+      newboxInfoText.scale.set(Math.min(box.size.x, box.size.y) / 2, Math.min(box.size.x, box.size.y) / 2, box.size.z);
+      newboxInfoText.rotation.z = - 1.57;
+      newboxInfoText.updateMatrixWorld();
+      this.cube.boxInfoText = newboxInfoText;
     }
   }
   removeProjectedRects() {

--- a/front/app/labeling_tool/pcd_tool/view_controller.jsx
+++ b/front/app/labeling_tool/pcd_tool/view_controller.jsx
@@ -132,6 +132,25 @@ class ViewController extends React.Component {
           }
           label="Show Object-ids"
         />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={this.props.tool.state.visualizeBoxInfo}
+              onChange={(event) => {
+                this.props.tool.setState({
+                  visualizeBoxInfo: event.target.checked
+                }, () => {
+                  this.props.tool.pcdBBoxes.forEach((item)=>{item.updateBoxInfoTextMesh()});
+                  this.props.tool.redrawRequest();
+                  this.forceUpdate();
+                })
+              }}
+              name="show-box-info"
+              color="primary"
+            />
+          }
+          label="Show Box Info"
+        />
         <Typography id="view-controller-point-size" gutterBottom>
           Point-size:
         </Typography>


### PR DESCRIPTION
## What?

- ボックス修正中に位置やサイズの情報をテキストで表示

## Why?

編集中にボックス情報を見たい

## TODOs

- [x] テキスト表示
- [x] テキストの位置・サイズ調整
- [x] テキスト表示・非表示の切り替え機能追加

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

![画面収録 2020-08-31 16 58 02](https://user-images.githubusercontent.com/13210107/91697075-7ac6b800-ebab-11ea-8514-5c8174c88a83.gif)
