### PR TITLE
Add keymap for set height

### DIFF
--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -1,6 +1,10 @@
 export const keymapDefault = [
   //view
   {
+    "keys": ["KeyM"],
+    "command": "change_tool_mode"
+  },
+  {
     "keys": ["shift+ShiftLeft", "shift+ShiftRight", "ShiftLeft", "ShiftRight", "Space"],
     "command": "change_edit_mode"
   },
@@ -201,6 +205,10 @@ export const keymapDefault = [
   {
     "keys": [],
     "command": "bbox_z_size_decrement_big",
+  },
+  {
+    "keys": ["shift+KeyH"],
+    "command": "bbox_set_height",
   },
 ]
 

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -12,7 +12,7 @@ import PCDBBox from './pcd_tool/pcd_bbox';
 import EditBar from './pcd_tool/edit_bar';
 import ViewController from './pcd_tool/view_controller'
 
-import {execKeyCommand} from './key_control/index'
+import { execKeyCommand } from './key_control/index';
 
 // 3d eidt arrow
 const arrowColors = [0xff0000, 0x00ff00, 0x0000ff],
@@ -498,6 +498,9 @@ class PCDLabelTool extends React.Component {
         this.addLabelOfBBox(pcdBBox);
         this.redrawRequest();
       });
+      execKeyCommand("bbox_set_height", e.originalEvent, () => {
+        this.setHeight();
+      })
     },
     keyup: (e) => {
       execKeyCommand("change_edit_mode", e.originalEvent, () => {


### PR DESCRIPTION
m## What?
- setHeight を発火するキーマップを追加した (`shift+KeyH`)

## Why?
- 利便性向上のため