### PR TITLE
Enable zoom with mouse scroll on mac

### DIFF
--- a/front/static/js/labeling_tool/OrbitControls.js
+++ b/front/static/js/labeling_tool/OrbitControls.js
@@ -516,6 +516,18 @@ THREE.OrbitControls = function ( object, domElement ) {
 
 			dollyIn( getZoomScale() );
 
+		} else {  // For mouse scroll on Mac OS
+
+			if (event.deltaX < 0) {
+
+				dollyOut( getZoomScale() );
+
+			} else if (event.deltaX > 0) {
+
+				dollyIn( getZoomScale() );
+
+			}
+
 		}
 
 		scope.update();


### PR DESCRIPTION
## What?

- MacOSでのマウススクロールでズームを有効化

## Why?

Macでマウスのスクロールが効かない

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]
