### PR TITLE
Prompt if there's unsaved change

### DIFF
--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -227,6 +227,15 @@ class Controls extends React.Component {
     window.addEventListener('resize', () => {
       this.resize();
     });
+
+    // Prompt if there's unsaved changes
+    window.addEventListener("beforeunload", (e) => {
+      if (this.props.annotation.isChanged()) {
+        const confirmationMessage = '保存されていない変更がありますが閉じますか？';
+        (e || window.event).returnValue = confirmationMessage;
+        return confirmationMessage;
+      }
+    });
   }
 
   selectKlass(kls) {

--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -229,10 +229,11 @@ class Controls extends React.Component {
     });
 
     // Prompt if there's unsaved changes
-    window.addEventListener("beforeunload", (e) => {
+    window.addEventListener("beforeunload", (event) => {
       if (this.props.annotation.isChanged()) {
-        const confirmationMessage = '保存されていない変更がありますが閉じますか？';
-        (e || window.event).returnValue = confirmationMessage;
+        const confirmationMessage = '保存されていない変更がありますが本当に閉じますか？';
+        event.preventDefault();
+        event.returnValue = confirmationMessage;
         return confirmationMessage;
       }
     });


### PR DESCRIPTION
## What?

- 保存されていない変更がある状態でページを移動しようとするとプロンプトを表示
- ページの更新・移動・タブを閉じる・ブラウザを閉じる際にプロンプトが出る

## Why?

誤って保存せずにタブを閉じる問題を防ぎたい

## See also [Optional]

- beforeunloadイベント: https://developer.mozilla.org/ja/docs/Web/API/Window/beforeunload_event

## Screenshot or video [Optional]

![画面収録 2020-09-02 18 07 13](https://user-images.githubusercontent.com/13210107/91962448-8222c880-ed47-11ea-9ffb-56cbeedf5583.gif)
