### PR TITLE
Add checkbox to toggle showing projected rects

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -37,6 +37,7 @@ class PCDLabelTool extends React.Component {
       },
       visualizeObjectIds: false,
       visualizeBoxInfo: true,
+      visualizeProjectedRects: true,
       cameraHelperSettings: {
         isUpdating: false,
         visible: true,

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -402,6 +402,8 @@ export default class PCDBBox {
       return
     }
     this.removeProjectedRects();
+    if (!this.pcdTool.state.visualizeProjectedRects) return;
+
     Object.entries(this.pcdTool.props.labelTool.candidateCalibrations).forEach(([key, value]) => {
       const candidateId = Number(key);
       const calibrationFiles = this.pcdTool.props.labelTool.calibrations.filter((item) => {

--- a/front/app/labeling_tool/pcd_tool/view_controller.jsx
+++ b/front/app/labeling_tool/pcd_tool/view_controller.jsx
@@ -151,6 +151,25 @@ class ViewController extends React.Component {
           }
           label="Show Box Info"
         />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={this.props.tool.state.visualizeProjectedRects}
+              onChange={(event) => {
+                this.props.tool.setState({
+                  visualizeProjectedRects: event.target.checked
+                }, () => {
+                  this.props.tool.pcdBBoxes.forEach((item)=>{item.update2DBox()});
+                  this.props.tool.redrawRequest();
+                  this.forceUpdate();
+                })
+              }}
+              name="show-projected-rects"
+              color="primary"
+            />
+          }
+          label="Show Projected Rects"
+        />
         <Typography id="view-controller-point-size" gutterBottom>
           Point-size:
         </Typography>


### PR DESCRIPTION
## What?

- 画像へのボックスの投影の表示・非表示をトグルできるチェックボックスの追加

## Why?

画像だけみたい時に邪魔になる

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

![名称未設定](https://user-images.githubusercontent.com/13210107/92931007-cb78c380-f47d-11ea-9fec-c01f403aa845.gif)
