### PR TITLE
Shrink the interval of bbox-move

### DIFF
--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -159,16 +159,16 @@ class Controls extends React.Component {
                       }
                       switch(action){
                         case "increment":
-                          box_d[param][axis] = 0.05
+                          box_d[param][axis] = 0.01
                           break
                         case "decrement":
-                          box_d[param][axis] = -0.05
+                          box_d[param][axis] = -0.01
                           break
                         case "increment_big":
-                          box_d[param][axis] = 0.5
+                          box_d[param][axis] = 0.1
                           break
                         case "decrement_big":
-                          box_d[param][axis] = -0.5
+                          box_d[param][axis] = -0.1
                           break
                       }
                       execKeyCommand(command, e.originalEvent, () => {


### PR DESCRIPTION
## What?
bbox選択状態で矢印キーによるbboxの移動幅・サイズ調整幅を小さくした
矢印キーのみ: 0.5 -> 0.1
Shift + 矢印キー: 0.05 -> 0.01

## Why?
歩行者の位置・大きさなどは細かく調整したいから
