### PR TITLE
Add a template for pedestrian and adjusted template z

### DIFF
--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -64,6 +64,10 @@ export const keymapDefault = [
     "keys": ["alt+Digit7"],
     "command": "template_add_mortorcycle",
   },
+  {
+    "keys": ["alt+Digit8"],
+    "command": "template_add_pedestrian",
+  },
 
   // history
   {

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -413,7 +413,7 @@ class PCDLabelTool extends React.Component {
         const pcdBBox = this.createBBox({
           'x_3d': 0,
           'y_3d': 0,
-          'z_3d': -1.35,
+          'z_3d': 0,
           'width_3d': 3.4,
           'height_3d': 1.5,
           'length_3d': 1.8,
@@ -426,7 +426,7 @@ class PCDLabelTool extends React.Component {
         const pcdBBox = this.createBBox({
           'x_3d': 0,
           'y_3d': 0,
-          'z_3d': -1.35,
+          'z_3d': 0,
           'width_3d': 4.5,
           'height_3d': 1.7,
           'length_3d': 1.5,
@@ -439,7 +439,7 @@ class PCDLabelTool extends React.Component {
         const pcdBBox = this.createBBox({
           'x_3d': 0,
           'y_3d': 0,
-          'z_3d': -1.35,
+          'z_3d': 0,
           'width_3d': 4.8,
           'height_3d': 1.8,
           'length_3d': 1.8,
@@ -452,7 +452,7 @@ class PCDLabelTool extends React.Component {
         const pcdBBox = this.createBBox({
           'x_3d': 0,
           'y_3d': 0,
-          'z_3d': -1.35,
+          'z_3d': 0,
           'width_3d': 3.4,
           'height_3d': 1.5,
           'length_3d': 1.8,
@@ -465,7 +465,7 @@ class PCDLabelTool extends React.Component {
         const pcdBBox = this.createBBox({
           'x_3d': 0,
           'y_3d': 0,
-          'z_3d': -1.35,
+          'z_3d': 0,
           'width_3d': 4.5,
           'height_3d': 1.7,
           'length_3d': 1.8,
@@ -478,7 +478,7 @@ class PCDLabelTool extends React.Component {
         const pcdBBox = this.createBBox({
           'x_3d': 0,
           'y_3d': 0,
-          'z_3d': -1.35,
+          'z_3d': 1.0,
           'width_3d': 8,
           'height_3d': 2.2,
           'length_3d': 3.5,
@@ -491,10 +491,23 @@ class PCDLabelTool extends React.Component {
         const pcdBBox = this.createBBox({
           'x_3d': 0,
           'y_3d': 0,
-          'z_3d': -1.35,
+          'z_3d': 0,
           'width_3d': 2.0,
           'height_3d': 0.8,
           'length_3d': 1.5,
+          'rotation_y': 0,
+        });
+        this.addLabelOfBBox(pcdBBox);
+        this.redrawRequest();
+      });
+      execKeyCommand("template_add_pedestrian", e.originalEvent, () => {
+        const pcdBBox = this.createBBox({
+          'x_3d': 0,
+          'y_3d': 0,
+          'z_3d': 0,
+          'width_3d': 0.5,
+          'height_3d': 0.5,
+          'length_3d': 1.67,
           'rotation_y': 0,
         });
         this.addLabelOfBBox(pcdBBox);


### PR DESCRIPTION
## What?
- 歩行者用のテンプレートを追加 (0.5 x 0.5 x 1.67)
- テンプレートのz座標を調整

## Why?
- 歩行者のテンプレートがなかったため
- デフォルトのz座標が低すぎて地面に埋もれていたため