### PR TITLE
Change the border-width of the selected box

### DIFF
--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -19,7 +19,7 @@ const BBoxParams = {
     rect: {
       selected: {
         'stroke': 'red',
-        'stroke-width': 10,
+        'stroke-width': 6,
         'fill': '#fff',
         'fill-opacity': 0,
         'cursor': 'all-scroll'

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -96,7 +96,7 @@ export default class PCDBBox {
   updateSelected(selected) {
     this.selected = selected;
     this.cube.meshFrame.setStatus(selected, false);
-    this.cube.meshFrame.setBold(selected);
+    // this.cube.meshFrame.setBold(selected);
     const box = this.box;
     this.cube.meshFrame.setParam(box.pos, box.size, box.yaw);
     // Update mesh


### PR DESCRIPTION
## What?
選択されているボックスの境界線の幅を選択前と同じになるように変更

## Why?
境界線が太すぎると歩行者のラベル付けか難しいため