### PR TITLE
Add state `isMouseOnTool`, Merge `view` and `edit` mode

### DIFF
--- a/front/app/labeling_tool/key_control/index.js
+++ b/front/app/labeling_tool/key_control/index.js
@@ -2,11 +2,11 @@ import { keymap } from './key_map/index'
 
 // Disable browser's default key-commands
 window.addEventListener('keydown', event => {
-  if (event.ctrlKey && 'cvxspwuaz'.indexOf(event.key) !== -1) {
+  if (event.ctrlKey && 'cvsuz'.indexOf(event.key) !== -1) {
     event.preventDefault();
     event.returnValue = '';
   }
-  if (event.metaKey && 'cvxspwuaz'.indexOf(event.key) !== -1) {
+  if (event.metaKey && 'cvsuz'.indexOf(event.key) !== -1) {
     event.preventDefault();
     event.returnValue = '';
   }

--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -11,10 +11,6 @@ export const keymapDefault = [
     "command": "change_tool_mode"
   },
   {
-    "keys": ["shift+ShiftLeft", "shift+ShiftRight", "ShiftLeft", "ShiftRight", "Space"],
-    "command": "change_edit_mode"
-  },
-  {
     "keys": ["Digit0"],
     "command": "reset_camera",
   },

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -518,6 +518,9 @@ class PCDLabelTool extends React.Component {
         this.setHeight();
       })
     },
+    keyup: ((e) => {
+
+    }),
   };
 
   setActive(isActive) {

--- a/front/static/js/labeling_tool/OrbitControls.js
+++ b/front/static/js/labeling_tool/OrbitControls.js
@@ -67,7 +67,7 @@ THREE.OrbitControls = function ( object, domElement ) {
 	this.autoRotateSpeed = 2.0; // 30 seconds per round when fps is 60
 
 	// Set to false to disable use of the keys
-	this.enableKeys = true;
+	this.enableKeys = false;
 
 	// The four arrow keys
 	// this.keys = { LEFT: 37, UP: 38, RIGHT: 39, BOTTOM: 40 };


### PR DESCRIPTION
## What?
- Controls.js のステートに `isMouseOnTool` を追加 (マウスポインタがツール上にあるときにtrueになる)
- PCDTool の `view` モードと `edit` モードを融合
- 一部のキーバインドをツール内でしか発動しない様に変更
  - bboxの作成・削除・移動・サイズ変更・回転
  - ビューの切り替え（俯瞰表示・横表示）
- `object_id` や フレーム番号の入力時にキーバインドが発動される問題を解決

## Why?
- 画面操作時に Shift キーを押すのが面倒なため
