### PR TITLE
Open a dialog when pasting multiple labels

### DIFF
--- a/front/app/labeling_tool/clipboard.jsx
+++ b/front/app/labeling_tool/clipboard.jsx
@@ -34,7 +34,16 @@ class Clipboard extends React.Component {
   }
   paste() {
     const copy = this.state.copy;
-    this.props.annotation.pasteLabels(copy);
+    if (copy !== null) {
+      if (copy.length === 1) {
+        this.props.annotation.pasteLabels(copy);
+      } else {
+        let TEXT = '複数のラベルを貼り付けます';
+        if (window.confirm(TEXT)) {
+          this.props.annotation.pasteLabels(copy);
+        }
+      }
+    }
   }
 
   render() {


### PR DESCRIPTION
## What?
複数のラベルをペーストする際に確認ダイアログを表示する機能を追加

## Why?
気づかない間にCOPY ALLしてラベルが重複してしまうのを防ぐため