### PR TITLE
Open a dialog when applying `set-height` to multiple boxes

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -600,7 +600,11 @@ class PCDLabelTool extends React.Component {
     if (tgt !== null) {
       bboxes = [tgt.bbox[this.candidateId]];
     } else {
-      bboxes = Array.from(this.pcdBBoxes);
+      if ( window.confirm("すべてのボックスの高さを自動修正しますか？") ) {
+        bboxes = Array.from(this.pcdBBoxes);
+      }else {
+        bboxes = []
+      }
     }
     const points = this._currentPointMesh.geometry.vertices;
     let changedLabel = null;


### PR DESCRIPTION
## What?
何もボックスを選択していない状態で `SET HEIGHT` するとダイアログを出す機能を追加

## Why?
誤操作ですべてのボックスの高さを変えてしまうのを防ぐため

## Screenshot or video [Optional]
![screencast](https://user-images.githubusercontent.com/24401842/93154898-c9458c00-f73f-11ea-983a-bac23a5b4786.gif)
