### PR TITLE
Resize bbox using template keymap

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -409,110 +409,56 @@ class PCDLabelTool extends React.Component {
         this.redrawRequest();
       });
 
+      const handleTemplate = (bboxSize) => {
+        const tgt = this.props.controls.getTargetLabel();
+        if(tgt){
+          const bbox = tgt.bbox[this.candidateId];
+          bbox.setBboxParams({
+            'pos': bbox.box.pos,
+            'size': bboxSize,
+            'yaw': bbox.box.yaw,
+            });
+          var changedLabel = bbox.label.createHistory(null)
+          changedLabel.addHistory()
+        }else{
+          const pcdBBox = this.createBBox({
+            'x_3d': 0,
+            'y_3d': 0,
+            'z_3d': 0,
+            'width_3d': bboxSize.x,
+            'height_3d': bboxSize.y,
+            'length_3d': bboxSize.z,
+            'rotation_y': 0,
+          });
+          this.addLabelOfBBox(pcdBBox);
+          this.redrawRequest();
+        }
+      }
+
       // adding templates
       execKeyCommand("template_add_kcar", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 0,
-          'width_3d': 3.4,
-          'height_3d': 1.5,
-          'length_3d': 1.8,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 3.4, 'y': 1.5, 'z': 1.8 })
       });
       execKeyCommand("template_add_sedan", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 0,
-          'width_3d': 4.5,
-          'height_3d': 1.7,
-          'length_3d': 1.5,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 4.5, 'y': 1.7, 'z': 1.5 })
       });
       execKeyCommand("template_add_minivan", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 0,
-          'width_3d': 4.8,
-          'height_3d': 1.8,
-          'length_3d': 1.8,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 4.8, 'y': 1.8, 'z': 1.8 })
       });
       execKeyCommand("template_add_small_sized_track", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 0,
-          'width_3d': 3.4,
-          'height_3d': 1.5,
-          'length_3d': 1.8,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 3.4, 'y': 1.5, 'z': 1.8 })
       });
       execKeyCommand("template_add_middle_sized_track", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 0,
-          'width_3d': 4.5,
-          'height_3d': 1.7,
-          'length_3d': 1.8,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 4.5, 'y': 1.7, 'z': 1.8 })
       });
       execKeyCommand("template_add_large_sized_track", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 1.0,
-          'width_3d': 8,
-          'height_3d': 2.2,
-          'length_3d': 3.5,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 8.0, 'y': 2.2, 'z': 3.5 })
       });
       execKeyCommand("template_add_mortorcycle", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 0,
-          'width_3d': 2.0,
-          'height_3d': 0.8,
-          'length_3d': 1.5,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 2.0, 'y': 0.8, 'z': 1.5 })
       });
       execKeyCommand("template_add_pedestrian", e.originalEvent, () => {
-        const pcdBBox = this.createBBox({
-          'x_3d': 0,
-          'y_3d': 0,
-          'z_3d': 0,
-          'width_3d': 0.5,
-          'height_3d': 0.5,
-          'length_3d': 1.67,
-          'rotation_y': 0,
-        });
-        this.addLabelOfBBox(pcdBBox);
-        this.redrawRequest();
+        handleTemplate({ 'x': 0.5, 'y': 0.5, 'z': 1.67 })
       });
       execKeyCommand("bbox_set_height", e.originalEvent, () => {
         this.setHeight();

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -438,34 +438,34 @@ export default class PCDBBox {
     box.objectId = id
     this.updateParam();
   }
-  shiftBboxParams(box_d){
+  shiftBboxParams(bboxParamsD){
     const box = this.box;
     box.size.set(
-      box.size.x + box_d.size.x,
-      box.size.y + box_d.size.y,
-      box.size.z + box_d.size.z,
+      box.size.x + bboxParamsD.size.x,
+      box.size.y + bboxParamsD.size.y,
+      box.size.z + bboxParamsD.size.z,
     )
     box.pos.set(
-      box.pos.x + box_d.pos.x,
-      box.pos.y + box_d.pos.y,
-      box.pos.z + box_d.pos.z,
+      box.pos.x + bboxParamsD.pos.x,
+      box.pos.y + bboxParamsD.pos.y,
+      box.pos.z + bboxParamsD.pos.z,
     )
-    box.yaw = box.yaw + box_d.yaw
+    box.yaw = box.yaw + bboxParamsD.yaw
     this.updateParam();
   }
-  setBboxParams(new_box){
+  setBboxParams(boxParams){
     const box = this.box;
     box.size.set(
-      new_box.size.x,
-      new_box.size.y,
-      new_box.size.z,
+      boxParams.size.x,
+      boxParams.size.y,
+      boxParams.size.z,
     )
     box.pos.set(
-      new_box.pos.x,
-      new_box.pos.y,
-      new_box.pos.z,
+      boxParams.pos.x,
+      boxParams.pos.y,
+      boxParams.pos.z,
     )
-    box.yaw = new_box.yaw
+    box.yaw = boxParams.yaw
     this.updateParam();
   }
   rotateFront(n) {


### PR DESCRIPTION
## What?
- テンプレート用のキー操作で、選択中の bbox のサイズを変更可能

## Why?
- 要望があったため

## See also [Optional]
- [機能要望 16](https://docs.google.com/spreadsheets/d/1MCHDHhgf6Mze6HEjNLPUhm_VbuRmYitumRv0xquYiMw)
- [Notion](https://www.notion.so/humandatawarelab/6b574e30eff4430a863a63555cc143f0)

## Screenshot or video [Optional]

![export](https://user-images.githubusercontent.com/8692594/93187132-6a513880-f77a-11ea-90a1-ae9936ad07f0.gif)
