### PR TITLE
Disable word wrap at label list

### DIFF
--- a/front/app/labeling_tool/annotation.js
+++ b/front/app/labeling_tool/annotation.js
@@ -589,7 +589,7 @@ class LabelItem extends React.Component {
           className={classes.colorPane}
           style={{ backgroundColor: this.state.color }}
         />
-        <ListItemText primary={label.toString()} />
+        <ListItemText primary={label.toString()} className={classes.listItemText} />
       </ListItem>
     );
   }

--- a/front/app/labeling_tool/tool-style.js
+++ b/front/app/labeling_tool/tool-style.js
@@ -34,6 +34,9 @@ export const toolStyle = theme => ({
   selectedListItem: {
     backgroundColor: '#eee',
   },
+  listItemText: {
+    whiteSpace: 'nowrap',
+  },
   appBar: {
     width: '100%',
     height: appBarHeight


### PR DESCRIPTION
## What?

ラベル一覧のところで文字を折り返さずスクロールするようにした

## Why?

折り返すと見辛い

## See also [Optional]

参考: https://stackoverflow.com/a/59521967

## Screenshot or video [Optional]

![画面収録 2020-09-15 22 07 52-edited](https://user-images.githubusercontent.com/13210107/93217224-b49adf80-f7a3-11ea-824f-4b3a36241e33.gif)
