### PR TITLE
Enable zooming image

### DIFF
--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -347,6 +347,9 @@ class Controls extends React.Component {
   getTools() {
     return this.props.tools;
   }
+  getPCDActive() {
+    return this.state.isActivePCD;
+  }
   setPCDActive(isActive) {
     const prevState = this.state.isActivePCD;
     const pcdIndex = this.pcdToolIndex;

--- a/front/app/labeling_tool/image_label_tool.jsx
+++ b/front/app/labeling_tool/image_label_tool.jsx
@@ -71,7 +71,8 @@ class ImageLabelTool extends React.Component {
   render() {
     const classes = this.props.classes;
     const mainScale = this.state.scale * MAIN_SCREEN_SCALE;
-    const wipeScale = this.state.isWipeZoomed ? 
+    // Zoom wipe only when pcd tool is active
+    const wipeScale = this.state.isWipeZoomed && this.props.controls.getPCDActive() ? 
       this.state.scale * WIPE_SCREEN_SCALE * WIPE_ZOOM_RATE : 
       this.state.scale * WIPE_SCREEN_SCALE;
     const mainMargin = this._wrapperSize.width - this._imageSize.width * mainScale;

--- a/front/app/labeling_tool/image_label_tool.jsx
+++ b/front/app/labeling_tool/image_label_tool.jsx
@@ -45,12 +45,14 @@ const imageToolStyle = {
 
 const MAIN_SCREEN_SCALE = 0.68;
 const WIPE_SCREEN_SCALE = 1 - MAIN_SCREEN_SCALE;
+const WIPE_ZOOM_RATE = 2;
 class ImageLabelTool extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       scale: 1.0,
-      isWipe: false
+      isWipe: false,
+      isWipeZoomed: false,
     };
     this._element = React.createRef();
     this._wipeElement = React.createRef();
@@ -69,7 +71,9 @@ class ImageLabelTool extends React.Component {
   render() {
     const classes = this.props.classes;
     const mainScale = this.state.scale * MAIN_SCREEN_SCALE;
-    const wipeScale = this.state.scale * WIPE_SCREEN_SCALE;
+    const wipeScale = this.state.isWipeZoomed ? 
+      this.state.scale * WIPE_SCREEN_SCALE * WIPE_ZOOM_RATE : 
+      this.state.scale * WIPE_SCREEN_SCALE;
     const mainMargin = this._wrapperSize.width - this._imageSize.width * mainScale;
     const wipeWidth = this._imageSize.width * wipeScale;
     const ml = Math.min(mainMargin, wipeWidth);
@@ -112,6 +116,7 @@ class ImageLabelTool extends React.Component {
           ref={this._element}
           className={classes.main}
           style={mainStyle}
+          onClick={() => this.toggleZoom()}
         />
         <div
           ref={this._wipeElement}
@@ -129,6 +134,7 @@ class ImageLabelTool extends React.Component {
         <div
           className={classes.guard}
           style={guardStyle}
+          onClick={() => this.toggleZoom()}
         />
       </div>
     );
@@ -161,6 +167,13 @@ class ImageLabelTool extends React.Component {
   dataType = 'IMAGE';
   candidateId = -1;
 
+  toggleZoom() {
+    if (this.state.isWipeZoomed) {
+      this.setState({isWipeZoomed: false});
+    } else {
+      this.setState({isWipeZoomed: true});
+    }
+  }
   isLoaded() {
     return this._loaded;
   }


### PR DESCRIPTION
## What?

- 点群を表示する際の画像ワイプをズームできるようにした
- ズームのパラメータは固定
- 画像ワイプをクリックするとズーム or not を切り替え

## Why?

ズームできると便利

## TODOs

- [x] クリックでズーム実装
- [x] 3Dではなくてカメラ画像ツールでもズームされてしまう問題を修正

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

![画面収録 2020-09-17 15 58 30](https://user-images.githubusercontent.com/13210107/93431896-c0031d80-f8ff-11ea-8833-880c5d4df53c.gif)
