### PR TITLE
Add shortcut for rotateFront

### DIFF
--- a/front/app/labeling_tool/key_control/key_map/default.js
+++ b/front/app/labeling_tool/key_control/key_map/default.js
@@ -111,6 +111,14 @@ export const keymapDefault = [
     "keys": ["Escape"],
     "command": "deselect_bbox",
   },
+  {
+    "keys": ["KeyR"],
+    "command": "rotate_front_clockwise",
+  },
+  {
+    "keys": ["shift+KeyR"],
+    "command": "rotate_front_counterclockwise",
+  },
 
   // move
   {

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -468,6 +468,20 @@ class PCDLabelTool extends React.Component {
       execKeyCommand("bbox_set_height", e.originalEvent, () => {
         this.setHeight();
       })
+      execKeyCommand("rotate_front_clockwise", e.originalEvent, () => {
+        const tgt = this.props.controls.getTargetLabel();
+        if(tgt){
+          const bbox = tgt.bbox[this.candidateId];
+          bbox.rotateFront(-1);
+        }
+      })
+      execKeyCommand("rotate_front_counterclockwise", e.originalEvent, () => {
+        const tgt = this.props.controls.getTargetLabel();
+        if(tgt){
+          const bbox = tgt.bbox[this.candidateId];
+          bbox.rotateFront(1);
+        }
+      })
     },
     keyup: ((e) => {
 

--- a/front/app/labeling_tool/pcd_tool/base_edit_bar.jsx
+++ b/front/app/labeling_tool/pcd_tool/base_edit_bar.jsx
@@ -58,6 +58,7 @@ export default class BasePCDEditBar extends React.Component {
   render() {
     const {
       setObjectId,
+      rotateFront,
       objectId
     } = this.props;
     return (
@@ -65,7 +66,29 @@ export default class BasePCDEditBar extends React.Component {
         <Typography component="h3" variant="body1">
           Bounding Box
         </Typography>
-        <div style={{width: "100%"}}>
+        <div style={{width: "100%", paddingTop: "10px"}}>
+          <div style={{marginBottom: "10px"}}>
+            <Typography component="h4" variant="body2">
+              Rotate Front
+            </Typography>
+
+            <Grid container>
+              <Grid item xs={6}>
+                <Button
+                  onClick={() => rotateFront(1)}
+                >
+                  <RotateLeft />
+                </Button>
+              </Grid>
+              <Grid item xs={6}>
+                <Button
+                  onClick={() => rotateFront(-1)}
+                >
+                  <RotateRight />
+                </Button>
+              </Grid>
+            </Grid>
+          </div>
           <div style={{marginBottom: "32px"}}>
             <Typography component="h4" variant="body2">
               Position

--- a/front/app/labeling_tool/pcd_tool/edit_bar.jsx
+++ b/front/app/labeling_tool/pcd_tool/edit_bar.jsx
@@ -33,6 +33,10 @@ class PCDEditBar extends React.Component {
     changedLabel.addHistory()
     this.forceUpdate() // necessary to update input value
   }
+  rotateFront = (direction) => {  // Rotate left if direction = 1, or right if direction = -1
+    const bbox = this.props.bbox;
+    bbox.rotateFront(direction)
+  }
   render() {
     const bbox = this.props.bbox;
     if(bbox == null){
@@ -45,6 +49,7 @@ class PCDEditBar extends React.Component {
           box={bbox.box}
           setBboxParams={this.setBboxParams}
           setObjectId={this.setObjectId}
+          rotateFront={this.rotateFront}
           objectId={bbox.box.objectId}
         />
       </div>


### PR DESCRIPTION
## What?

- Bboxのフロントを回転させるショートカットを追加
  - KeyRで時計回り回転、shift+KeyRで反時計回り回転
- 同時に消えてしまっていたrotateFront機能のUIを復活

## Why?

機能が消えていた＆ショートカットキーの要望があった

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

<img width="1920" alt="スクリーンショット 2020-09-25 10 13 00" src="https://user-images.githubusercontent.com/13210107/94215594-1849a900-ff18-11ea-9a39-198f3de8d114.png">
