### PR TITLE
fix: lint checking

### DIFF
--- a/front/app/labeling_tool/klass_set.js
+++ b/front/app/labeling_tool/klass_set.js
@@ -103,7 +103,7 @@ class KlassSet extends React.Component {
     }
     return list;
   }
-  handleSelectChange = (e) => {
+  handleSelectChange = e => {
     const newVal = e.target.value;
     this.props.controls.selectKlass(this._klassList[newVal]);
     this.setState({ targetIndex: newVal });
@@ -116,6 +116,9 @@ class KlassSet extends React.Component {
           className={classes.ClassSelect}
           value={this.state.targetIndex}
           onChange={this.handleSelectChange}
+          onClose={
+            () => setTimeout(() => { document.activeElement.blur() }, 0)
+          }
         >
           {this.renderItems(classes)}
         </Select>


### PR DESCRIPTION
## What?
- クラスを選択した際に、`focus` が外れるようにした

## Why?
(モチベーションなど)
- `focus` が当たったままになり、操作を誤りやすいから

