### PR TITLE
Fix box texts rotation to camera

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -701,6 +701,16 @@ class PCDLabelTool extends React.Component {
 
     this._camera = camera;
     this._cameraControls = controls;
+    // Add callback when camera changed
+    this._cameraControls.addEventListener( 'change', () => {
+      const tgt = this.props.controls.getTargetLabel();
+      if(tgt){
+        const bbox = tgt.bbox[this.candidateId];
+
+        // Update text mesh
+        bbox.updateBoxInfoTextMesh();
+      }
+    } );
     // Save camera parameters for later reset
     this._cameraControls.saveState();
   }

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -382,7 +382,8 @@ export default class PCDBBox {
       const box = this.box;
       this.pcdTool._scene.add(newboxInfoText);
       newboxInfoText.position.set(box.pos.x + box.size.x / 2 - 0.4, box.pos.y - box.size.y / 2 - 0.6, box.pos.z);
-      newboxInfoText.rotation.z = - 1.57;
+      // Face to the camera
+      newboxInfoText.quaternion.copy(this.pcdTool._camera.quaternion);
       newboxInfoText.updateMatrixWorld();
       this.cube.boxInfoText = newboxInfoText;
     }

--- a/front/app/labeling_tool/pcd_tool/pcd_bbox.js
+++ b/front/app/labeling_tool/pcd_tool/pcd_bbox.js
@@ -281,7 +281,6 @@ export default class PCDBBox {
     geometry.translate(0, 0, 1.0);
     let text = new THREE.Mesh(geometry, matDark);
     text.visible = true;
-    text.rotation.z = -1.57;
     text.scale.set(1, 1, 1);
     return text;
   }


### PR DESCRIPTION
## What?

- ボックスの位置情報テキストのメッシュを常にカメラに向くようにした
  - Quaternionでカメラに向ける
  - OrbitControlでカメラ向きが変更された際にメッシュ更新関数を呼ぶ

## Why?

方向が固定でカメラを動かすと見辛い

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]

![画面収録 2020-09-30 16 00 47](https://user-images.githubusercontent.com/13210107/94653689-e92ba100-0336-11eb-8c98-2962b325c5a2.gif)
