### PR TITLE
Fix rotate front does not work when saving

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -473,6 +473,9 @@ class PCDLabelTool extends React.Component {
         if(tgt){
           const bbox = tgt.bbox[this.candidateId];
           bbox.rotateFront(-1);
+          bbox.updateSelected(true)
+          var changedLabel = bbox.label.createHistory(null)
+          changedLabel.addHistory()
         }
       })
       execKeyCommand("rotate_front_counterclockwise", e.originalEvent, () => {
@@ -480,6 +483,9 @@ class PCDLabelTool extends React.Component {
         if(tgt){
           const bbox = tgt.bbox[this.candidateId];
           bbox.rotateFront(1);
+          bbox.updateSelected(true)
+          var changedLabel = bbox.label.createHistory(null)
+          changedLabel.addHistory()
         }
       })
     },

--- a/front/app/labeling_tool/pcd_tool/edit_bar.jsx
+++ b/front/app/labeling_tool/pcd_tool/edit_bar.jsx
@@ -36,6 +36,9 @@ class PCDEditBar extends React.Component {
   rotateFront = (direction) => {  // Rotate left if direction = 1, or right if direction = -1
     const bbox = this.props.bbox;
     bbox.rotateFront(direction)
+    bbox.updateSelected(true)
+    var changedLabel = bbox.label.createHistory(null)
+    changedLabel.addHistory()
   }
   render() {
     const bbox = this.props.bbox;


### PR DESCRIPTION
## What?
- `rotateFront` の挙動を行う関数に、変更履歴を追加する操作を追加した

## Why?
- バグ修正のため

## See also [Optional]
- 機能要望 33

