### PR TITLE
Fix the bug that `undo` does not work for the first change

### DIFF
--- a/front/app/labeling_tool/controls.jsx
+++ b/front/app/labeling_tool/controls.jsx
@@ -157,9 +157,9 @@ class Controls extends React.Component {
                 const bbox = targetLabel.bbox[bkey]
                 if(bbox){
                   const shiftBboxParams = (bbox, box_d) => {
-                    bbox.shiftBboxParams(box_d);
                     var changedLabel = bbox.label.createHistory(null)
                     changedLabel.addHistory()
+                    bbox.shiftBboxParams(box_d);
                   }
                   ["x", "y", "z"].forEach(axis => {
                     ["pos", "size"].forEach(param => {

--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -472,20 +472,20 @@ class PCDLabelTool extends React.Component {
         const tgt = this.props.controls.getTargetLabel();
         if(tgt){
           const bbox = tgt.bbox[this.candidateId];
-          bbox.rotateFront(-1);
-          bbox.updateSelected(true)
           var changedLabel = bbox.label.createHistory(null)
           changedLabel.addHistory()
+          bbox.rotateFront(-1);
+          bbox.updateSelected(true)
         }
       })
       execKeyCommand("rotate_front_counterclockwise", e.originalEvent, () => {
         const tgt = this.props.controls.getTargetLabel();
         if(tgt){
           const bbox = tgt.bbox[this.candidateId];
-          bbox.rotateFront(1);
-          bbox.updateSelected(true)
           var changedLabel = bbox.label.createHistory(null)
           changedLabel.addHistory()
+          bbox.rotateFront(1);
+          bbox.updateSelected(true)
         }
       })
     },

--- a/front/app/labeling_tool/pcd_tool/edit_bar.jsx
+++ b/front/app/labeling_tool/pcd_tool/edit_bar.jsx
@@ -35,10 +35,10 @@ class PCDEditBar extends React.Component {
   }
   rotateFront = (direction) => {  // Rotate left if direction = 1, or right if direction = -1
     const bbox = this.props.bbox;
-    bbox.rotateFront(direction)
-    bbox.updateSelected(true)
     var changedLabel = bbox.label.createHistory(null)
     changedLabel.addHistory()
+    bbox.rotateFront(direction)
+    bbox.updateSelected(true)
   }
   render() {
     const bbox = this.props.bbox;


### PR DESCRIPTION
## What?
矢印キーでのボックス移動や90度回転コマンドを行った際に、 `undo` コマンドの1回目が動作しないバグを修正

## Why?
バグ修正のため