### PR TITLE
Add label count pane

### DIFF
--- a/front/app/labeling_tool/annotation.js
+++ b/front/app/labeling_tool/annotation.js
@@ -557,7 +557,11 @@ class Annotation extends React.Component {
         />
       );
     }
-    return list;
+    if (list.length > 0) {
+      return list;
+    } else {
+      return <ListItem>No bounding boxes in this frame</ListItem>;
+    }
   }
   renderLabelCount(classes) {
     if (this.state.labels === null) {
@@ -573,17 +577,21 @@ class Annotation extends React.Component {
         klassCount[labelKlass] = 1;
       }
     }
-    return (
-      <React.Fragment>
-        {Object.keys(klassCount).map((v, k) => (
-          <ListItem key={k} className={classes.listItem}>
-            <ListItemText>
-              {v}: {klassCount[v]}
-            </ListItemText>
-          </ListItem>
-        ))}
-      </React.Fragment>
-    );
+    if (Object.keys(klassCount).length > 0) {
+      return (
+        <React.Fragment>
+          {Object.keys(klassCount).map((v, k) => (
+            <ListItem key={k} className={classes.listItem}>
+              <ListItemText>
+                {v}: {klassCount[v]}
+              </ListItemText>
+            </ListItem>
+          ))}
+        </React.Fragment>
+      );
+    } else {
+      return <ListItem>No bounding boxes in this frame</ListItem>;
+    }
   }
 
   handleClickListHeader = e => {


### PR DESCRIPTION
## What?
- バウンディングボックスを種類別に表示する機能を追加
- 左下の `Bounding box` ペインから切り替え可能

## Why?
- バウンディングボックスのリストとそのクラス情報を左下のペインに集約したかったため、ペインを切り替える UI とした

## See also [Optional]
- 機能要望35

## Screenshot or video [Optional]
![Screen Shot 2020-10-05 at 17 00 40](https://user-images.githubusercontent.com/8692594/95063093-d949fd80-0738-11eb-93a6-ad69d65d9b3e.png)
