### PR TITLE
Set default coloring axis to z

### DIFF
--- a/front/app/labeling_tool/pcd_label_tool.jsx
+++ b/front/app/labeling_tool/pcd_label_tool.jsx
@@ -29,7 +29,7 @@ class PCDLabelTool extends React.Component {
         size: 0.05,
       },
       pointColoringSettings: {
-        axis: "none",
+        axis: "z",
         controllerMinValue: -10,
         controllerMaxValue: 10,
         minValue: -1,


### PR DESCRIPTION
## What?

Coloring axisのデフォルトをzに変更

## Why?

要望があったため

## See also [Optional]
- 関連するissueやPR番号へのリンク
- 参考にしたURLなど

## Screenshot or video [Optional]
